### PR TITLE
feat: add experience timeline section

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <ul class="nav-list">
           <li><a href="about.html">Обо мне</a></li>
           <li><a href="#skills">Навыки</a></li>
+          <li><a href="#experience">Опыт</a></li>
           <li><a href="#projects">Проекты</a></li>
           <li><a href="#testimonials">Отзывы</a></li>
           <li><a href="#contact">Контакты</a></li>
@@ -129,14 +130,56 @@
     </div>
   </section>
 
-  <!-- TESTIMONIALS -->
-<section class="section container" id="testimonials">
-  <div class="section-header reveal">
-    <h2>Отзывы</h2>
-    <p>Реальные задачи, конкретные цифры и результат. Имена обезличены по NDA.</p>
-  </div>
+  <!-- EXPERIENCE -->
+  <section id="experience" class="section container">
+    <div class="section-header reveal">
+      <h2>Опыт</h2>
+      <p>Ключевые вехи и проекты.</p>
+    </div>
+    <div class="timeline">
+      <article class="t-item reveal">
+        <div class="t-head">2024 — Наблюдаемость и качество данных</div>
+        <div class="t-body">
+          <ul>
+            <li>Внедрение SLI/SLA, тестов свежести и алертов</li>
+          </ul>
+        </div>
+      </article>
+      <article class="t-item reveal">
+        <div class="t-head">2023 — Стриминг CN→RU</div>
+        <div class="t-body">
+          <ul>
+            <li>Мониторинг статусов грузов в режиме реального времени</li>
+          </ul>
+        </div>
+      </article>
+      <article class="t-item reveal">
+        <div class="t-head">2022 — Калькулятор логистической стоимости</div>
+        <div class="t-body">
+          <ul>
+            <li>dbt-модели и витрины расходов</li>
+          </ul>
+        </div>
+      </article>
+      <article class="t-item reveal">
+        <div class="t-head">2021 — Дивидендная аналитика</div>
+        <div class="t-body">
+          <ul>
+            <li>ETL прайсов и автоматизированные дашборды</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+  </section>
 
-  <div class="testimonials">
+  <!-- TESTIMONIALS -->
+  <section class="section container" id="testimonials">
+    <div class="section-header reveal">
+      <h2>Отзывы</h2>
+      <p>Реальные задачи, конкретные цифры и результат. Имена обезличены по NDA.</p>
+    </div>
+
+    <div class="testimonials">
     <!-- Отзыв 1 -->
     <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
       <div class="quote-head">


### PR DESCRIPTION
## Summary
- add experience timeline section highlighting key projects
- link experience section from main navigation

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd20335eac8322b559b441834b871f