### PR TITLE
Add Open Graph and Twitter meta tags to pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,6 +4,16 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Обо мне — Artem Chernov</title>
+  <meta name="description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
+  <meta property="og:title" content="Обо мне — Artem Chernov" />
+  <meta property="og:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
+  <meta property="og:url" content="https://jaeviksodertra.github.io/about.html" />
+  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Обо мне — Artem Chernov" />
+  <meta name="twitter:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
+  <meta name="twitter:url" content="https://jaeviksodertra.github.io/about.html" />
+  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Artem Chernov — Data Engineer</title>
   <meta name="description" content="Мидл дата-инженер: ETL/ELT, стриминг, DWH, наблюдаемость. Проекты в логистике CN→RU и финтехе." />
+  <meta property="og:title" content="Artem Chernov — Data Engineer" />
+  <meta property="og:description" content="Мидл дата-инженер: ETL/ELT, стриминг, DWH, наблюдаемость. Проекты в логистике CN→RU и финтехе." />
+  <meta property="og:url" content="https://jaeviksodertra.github.io/" />
+  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Artem Chernov — Data Engineer" />
+  <meta name="twitter:description" content="Мидл дата-инженер: ETL/ELT, стриминг, DWH, наблюдаемость. Проекты в логистике CN→RU и финтехе." />
+  <meta name="twitter:url" content="https://jaeviksodertra.github.io/" />
+  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect rx='22' ry='22' x='4' y='4' width='92' height='92' fill='%2300d4ff'/%3E%3Ctext x='50' y='62' font-size='50' text-anchor='middle' fill='white' font-family='Arial'%3EDE%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- add Open Graph metadata to `index.html` and `about.html`
- include Twitter card tags mirroring OG data

## Testing
- `npx open-graph-scraper --url=http://localhost:8000/index.html` *(fails: 403 Forbidden)*
- `curl -H 'Content-Type: text/html; charset=utf-8' --data-binary @index.html https://validator.w3.org/nu/?out=gnu` *(fails: 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd203a1bb483228f290265a1f25a3a