### PR TITLE
feat: wire contact form and add status messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,3 +66,31 @@ document.querySelectorAll('.quote .more').forEach(btn => {
   });
 });
 
+// Отправка формы
+const contactForm = document.querySelector('.contact-form');
+contactForm?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const statusEl = contactForm.querySelector('.form-status');
+  statusEl.hidden = true;
+  const data = new FormData(contactForm);
+  try {
+    const response = await fetch(contactForm.action, {
+      method: contactForm.method,
+      body: data,
+      headers: { 'Accept': 'application/json' }
+    });
+    if (response.ok) {
+      contactForm.reset();
+      statusEl.textContent = 'Сообщение отправлено!';
+      statusEl.className = 'form-status success';
+    } else {
+      statusEl.textContent = 'Ошибка при отправке. Попробуйте позже.';
+      statusEl.className = 'form-status error';
+    }
+  } catch (err) {
+    statusEl.textContent = 'Ошибка сети. Попробуйте позже.';
+    statusEl.className = 'form-status error';
+  }
+  statusEl.hidden = false;
+});
+

--- a/index.html
+++ b/index.html
@@ -256,18 +256,19 @@
         <h3>Открыт к сотрудничеству</h3>
         <p>Домены: логистика/склады, финансы/отчётность, контент-аналитика. Форматы — консалтинг, разработка, поддержка.</p>
         <div class="contact-actions">
-          <a class="btn primary" href="mailto:hello@example.com">hello@example.com</a>
+          <a class="btn primary" href="mailto:83803087+JaevikSodertra@users.noreply.github.com">83803087+JaevikSodertra@users.noreply.github.com</a>
           <a class="btn ghost" href="https://github.com/JaevikSodertra" target="_blank" rel="noreferrer">GitHub</a>
         </div>
         <p class="form-note">Языки: RU / ZH / EN / JP (базово).</p>
       </div>
 
-      <form class="contact-form reveal" action="mailto:hello@example.com" method="post" enctype="text/plain">
+      <form class="contact-form reveal" action="https://formspree.io/f/mwkgebkn" method="POST">
         <label>Ваше имя <input required name="name" placeholder="Иван" /></label>
         <label>Email <input type="email" required name="email" placeholder="name@mail.com" /></label>
         <label>Сообщение <textarea required name="message" rows="4" placeholder="Нужно собрать витрину логистических затрат..." ></textarea></label>
         <button class="btn primary" type="submit">Отправить</button>
         <p class="form-note">* Для продакшн-формы позже подключим Formspree / любой бэкенд.</p>
+        <p class="form-status" hidden></p>
       </form>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -133,6 +133,9 @@ p{margin:0 0 16px;max-width:70ch} ul,li{margin:0 0 8px 20px;padding:0}
 .contact-form{display:grid;gap:10px;padding:18px;border:1px solid var(--border);border-radius:var(--radius);background:var(--panel)}
 .contact-form input,.contact-form textarea{width:100%;padding:12px 12px;border-radius:10px;border:1px solid var(--border);background:transparent;color:var(--text)}
 .form-note{color:var(--muted);font-size:12px;margin:6px 0 0}
+.form-status{font-size:14px;margin-top:4px}
+.form-status.success{color:var(--brand)}
+.form-status.error{color:#ff6b6b}
 .site-footer{margin-top:30px;padding:18px 0;border-top:1px solid var(--border)}
 .footer-inner{display:flex;align-items:center;justify-content:space-between}
 .to-top{color:var(--text);text-decoration:none;opacity:.85}


### PR DESCRIPTION
## Summary
- replace placeholder email with working address and Formspree endpoint
- display success or error message after contact form submission
- style status messages for clarity

## Testing
- `node --check app.js`
- `python3 -m http.server 8000 & PID=$!; sleep 1; kill $PID`


------
https://chatgpt.com/codex/tasks/task_e_68bd203d8a0883228daee3bb2b75fa3b