### PR TITLE
Add noopener to GitHub contact link

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
         <p>Домены: логистика/склады, финансы/отчётность, контент-аналитика. Форматы — консалтинг, разработка, поддержка.</p>
         <div class="contact-actions">
           <a class="btn primary" href="mailto:83803087+JaevikSodertra@users.noreply.github.com">83803087+JaevikSodertra@users.noreply.github.com</a>
-          <a class="btn ghost" href="https://github.com/JaevikSodertra" target="_blank" rel="noreferrer">GitHub</a>
+          <a class="btn ghost" href="https://github.com/JaevikSodertra" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>
         <p class="form-note">Языки: RU / ZH / EN / JP (базово).</p>
       </div>


### PR DESCRIPTION
## Summary
- ensure the GitHub link in the contact-actions block uses `rel="noopener noreferrer"`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd22f612f08322a41caabd8599b1ab