### PR TITLE
refactor: load Google Fonts via link tags

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,9 @@
   <meta name="twitter:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta name="twitter:url" content="https://jaeviksodertra.github.io/about.html" />
   <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
   <meta name="twitter:url" content="https://jaeviksodertra.github.io/" />
   <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect rx='22' ry='22' x='4' y='4' width='92' height='92' fill='%2300d4ff'/%3E%3Ctext x='50' y='62' font-size='50' text-anchor='middle' fill='white' font-family='Arial'%3EDE%3C/text%3E%3C/svg%3E">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
   <script type="application/ld+json">
   {

--- a/style.css
+++ b/style.css
@@ -1,6 +1,4 @@
 /* Шрифт */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
 :root{
   --bg:#0b0c10; --panel:rgba(255,255,255,.06); --text:#e8e8e8; --muted:#b8b8b8;
   --brand:#00d4ff; --brand-2:#7c4dff; --border:rgba(255,255,255,.12);


### PR DESCRIPTION
## Summary
- remove `@import` from stylesheet
- preconnect to Google Fonts and load Inter via `<link>` in HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd23007a8083228e5e952542ea43af