### PR TITLE
Use system color scheme when no saved theme

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,8 @@
 // Тема
 const themeToggle = document.getElementById('themeToggle');
 const saved = localStorage.getItem('theme');
-if (saved) document.documentElement.setAttribute('data-theme', saved);
+const initial = saved ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+document.documentElement.setAttribute('data-theme', initial);
 themeToggle?.addEventListener('click', () => {
   const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
   document.documentElement.setAttribute('data-theme', current);


### PR DESCRIPTION
## Summary
- Default theme now follows `prefers-color-scheme` when no saved preference exists
- Apply initial `data-theme` before attaching handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd23012d9c83229da8a025d297bf93