### PR TITLE
Add descriptive alt text for testimonial avatars

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
     <!-- Отзыв 1 -->
     <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
       <div class="quote-head">
-        <img class="avatar" src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?q=80&w=400&auto=format&fit=crop" alt="avatar" />
+        <img class="avatar" src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?q=80&w=400&auto=format&fit=crop" alt="Фото Ирины П." />
         <div>
           <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
             <span itemprop="name">Ирина П.</span>
@@ -220,7 +220,7 @@
     <!-- Отзыв 2 -->
     <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
       <div class="quote-head">
-        <img class="avatar" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?q=80&w=400&auto=format&fit=crop" alt="avatar" />
+        <img class="avatar" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?q=80&w=400&auto=format&fit=crop" alt="Фото Антона К." />
         <div>
           <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
             <span itemprop="name">Антон К.</span>
@@ -246,7 +246,7 @@
     <!-- Отзыв 3 -->
     <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
       <div class="quote-head">
-        <img class="avatar" src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?q=80&w=400&auto=format&fit=crop" alt="avatar" />
+        <img class="avatar" src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?q=80&w=400&auto=format&fit=crop" alt="Фото Веры Л." />
         <div>
           <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
             <span itemprop="name">Вера Л.</span>
@@ -272,7 +272,7 @@
     <!-- Отзыв 4 -->
     <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
       <div class="quote-head">
-        <img class="avatar" src="https://images.unsplash.com/photo-1527980965255-d3b416303d12?q=80&w=400&auto=format&fit=crop" alt="avatar" />
+        <img class="avatar" src="https://images.unsplash.com/photo-1527980965255-d3b416303d12?q=80&w=400&auto=format&fit=crop" alt="Фото Дмитрия С." />
         <div>
           <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
             <span itemprop="name">Дмитрий С.</span>


### PR DESCRIPTION
## Summary
- provide descriptive alt text for each testimonial avatar image

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2303169483229d8b17996f39cfdf