### PR TITLE
Add Plausible analytics tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,17 @@
 
 ## Деплой на GitHub Pages
 Репозиторий `JaevikSodertra/JaevikSodertra.github.io` автоматически публикуется через GitHub Pages из ветки `main`. После отправки коммита подождите несколько минут и проверьте сайт по адресу <https://jaeviksodertra.github.io/>.
+
+## Статистика посещений
+На сайте подключён self-hosted [Plausible](https://plausible.io/) (`https://plausible.example.com`, домен `jaeviksodertra.github.io`).
+
+Посмотреть метрики можно в панели <https://plausible.example.com/jaeviksodertra.github.io> (нужны учётные данные).
+
+### Исключение собственных визитов
+Чтобы не учитывать свою активность, один раз откройте сайт с параметром `?no-track`:
+
+```
+https://jaeviksodertra.github.io/?no-track
+```
+
+Страница установит флаг `plausible_ignore` в `localStorage`, и дальнейшие посещения с этого браузера не будут попадать в статистику. Чтобы снова считать визиты, удалите этот ключ из `localStorage`.

--- a/about.html
+++ b/about.html
@@ -19,6 +19,18 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <script>
+    if (location.search.includes('no-track')) {
+      localStorage.setItem('plausible_ignore', 'true');
+    }
+    if (!localStorage.getItem('plausible_ignore')) {
+      var s = document.createElement('script');
+      s.defer = true;
+      s.dataset.domain = 'jaeviksodertra.github.io';
+      s.src = 'https://plausible.example.com/js/script.js';
+      document.head.appendChild(s);
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/index.html
+++ b/index.html
@@ -31,6 +31,18 @@
     "sameAs":["https://github.com/JaevikSodertra"]
   }
   </script>
+  <script>
+    if (location.search.includes('no-track')) {
+      localStorage.setItem('plausible_ignore', 'true');
+    }
+    if (!localStorage.getItem('plausible_ignore')) {
+      var s = document.createElement('script');
+      s.defer = true;
+      s.dataset.domain = 'jaeviksodertra.github.io';
+      s.src = 'https://plausible.example.com/js/script.js';
+      document.head.appendChild(s);
+    }
+  </script>
 </head>
 <body>
   <!-- HEADER -->


### PR DESCRIPTION
## Summary
- hook self-hosted Plausible analytics into pages
- document stats dashboard and how to exclude your own visits

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd29094d4c8322924f40c37c1f8b5b