### PR TITLE
Redesign 404 page layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,10 +2,26 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Страница не найдена</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Страница не найдена</h1>
-  <p><a href="/">Перейти на главную</a></p>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="/"><span class="logo-dot"></span> Artem Chernov</a>
+    </div>
+    <div class="gradient"></div>
+  </header>
+
+  <main class="section container" style="text-align:center;">
+    <h1>Страница не найдена</h1>
+    <a class="btn primary" href="/">На главную</a>
+  </main>
+
+  <script src="app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style 404 page to match site header and layout
- add meta viewport and styles for mobile-friendly display

## Testing
- `curl -A "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1" -s http://localhost:8000/404.html | head -n 20`
- `npx playwright --help` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d7d05cc8322966643e0fe95e036