### PR TITLE
Centralize analytics in layout and remove inline scripts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,18 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{{ '/style.css' | relative_url }}" />
+  <script>
+    if (location.search.includes('no-track')) {
+      localStorage.setItem('plausible_ignore', 'true');
+    }
+    if (!localStorage.getItem('plausible_ignore')) {
+      var s = document.createElement('script');
+      s.defer = true;
+      s.dataset.domain = 'jaeviksodertra.github.io';
+      s.src = 'https://plausible.example.com/js/script.js';
+      document.head.appendChild(s);
+    }
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/about.html
+++ b/about.html
@@ -19,18 +19,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
-  <script>
-    if (location.search.includes('no-track')) {
-      localStorage.setItem('plausible_ignore', 'true');
-    }
-    if (!localStorage.getItem('plausible_ignore')) {
-      var s = document.createElement('script');
-      s.defer = true;
-      s.dataset.domain = 'jaeviksodertra.github.io';
-      s.src = 'https://plausible.example.com/js/script.js';
-      document.head.appendChild(s);
-    }
-  </script>
 </head>
 <body>
   <header class="site-header">

--- a/index.html
+++ b/index.html
@@ -22,29 +22,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
-  <script type="application/ld+json">
-  {
-    "@context":"https://schema.org",
-    "@type":"Person",
-    "name":"Artem Chernov",
-    "jobTitle":"Data Engineer",
-    "url":"https://JaevikSodertra.github.io/",
-    "knowsLanguage":["ru","zh","en","ja"],
-    "sameAs":["https://github.com/JaevikSodertra"]
-  }
-  </script>
-  <script>
-    if (location.search.includes('no-track')) {
-      localStorage.setItem('plausible_ignore', 'true');
-    }
-    if (!localStorage.getItem('plausible_ignore')) {
-      var s = document.createElement('script');
-      s.defer = true;
-      s.dataset.domain = 'jaeviksodertra.github.io';
-      s.src = 'https://plausible.example.com/js/script.js';
-      document.head.appendChild(s);
-    }
-  </script>
 </head>
 <body>
   <!-- HEADER -->


### PR DESCRIPTION
## Summary
- remove page-level inline scripts from index and about pages
- add Plausible analytics block to shared layout

## Testing
- `gem install jekyll --no-document` *(failed: 403 Forbidden)*
- `jekyll build` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d7935e08322b500c3bb66d73b33