### PR TITLE
Add optimized about page photo with styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,6 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
+      <img src="img/me.jpg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -77,6 +77,15 @@ p{margin:0 0 16px;max-width:70ch} ul,li{margin:0 0 8px 20px;padding:0}
 .section-header{margin-bottom:28px}
 .section-header p{color:var(--muted);margin:0}
 
+.about-photo{
+  width:200px;
+  height:auto;
+  max-width:100%;
+  border-radius:50%;
+  display:block;
+  margin:0 auto 24px;
+}
+
 /* Skills */
 .skills{display:flex;flex-wrap:wrap;gap:10px}
 .tag{padding:8px 12px;background:var(--panel);border:1px solid var(--border);border-radius:999px}


### PR DESCRIPTION
## Summary
- display personal photo under "Обо мне" heading with lazy loading and explicit dimensions
- style about page photo with responsive sizing and rounded corners
- reference external photo file; remove placeholder binary image from repository

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2f49ab248322aa661af2feea99fd