### PR TITLE
Limit latest posts via for loop parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,8 +326,8 @@
       <h2>Последние записи</h2>
     </div>
     <ul class="latest-posts">
-      {% assign posts = site.pages | where_exp: 'p', "p.path contains 'posts/'" | sort: 'date' | reverse | limit: 3 %}
-      {% for post in posts %}
+      {% assign posts = site.pages | where_exp: 'p', "p.path contains 'posts/'" | sort: 'date' | reverse %}
+      {% for post in posts limit: 3 %}
       <li><a href="{{ post.url }}">{{ post.title }}</a> <span>{{ post.date | date: "%d.%m.%Y" }}</span></li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- move `limit: 3` from `assign` to the `for` loop for latest posts

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3522603c8322aaa64fd620aff62f