### PR TITLE
Fix asset paths for HTML pages

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="../css/style.css" />
 </head>
 <body>
   <header class="site-header">
@@ -36,7 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
-      <img src="img/me.jpg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
+      <img src="../img/me.jpg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 
@@ -72,6 +72,6 @@
       <a href="index.html" class="to-top">← На главную</a>
     </div>
   </footer>
-  <script src="app.js" defer></script>
+  <script src="../js/app.js" defer></script>
 </body>
 </html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,401 @@
+---
+---
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Artem Chernov — Data Engineer</title>
+  <meta name="description" content="Мидл дата-инженер: ETL/ELT, стриминг, DWH, наблюдаемость. Проекты в логистике CN→RU и финтехе." />
+  <meta property="og:title" content="Artem Chernov — Data Engineer" />
+  <meta property="og:description" content="Мидл дата-инженер: ETL/ELT, стриминг, DWH, наблюдаемость. Проекты в логистике CN→RU и финтехе." />
+  <meta property="og:url" content="https://jaeviksodertra.github.io/" />
+  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Artem Chernov — Data Engineer" />
+  <meta name="twitter:description" content="Мидл дата-инженер: ETL/ELT, стриминг, DWH, наблюдаемость. Проекты в логистике CN→RU и финтехе." />
+  <meta name="twitter:url" content="https://jaeviksodertra.github.io/" />
+  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <link rel="canonical" href="https://jaeviksodertra.github.io/" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect rx='22' ry='22' x='4' y='4' width='92' height='92' fill='%2300d4ff'/%3E%3Ctext x='50' y='62' font-size='50' text-anchor='middle' fill='white' font-family='Arial'%3EDE%3C/text%3E%3C/svg%3E">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../css/style.css" />
+</head>
+<body>
+  <!-- HEADER -->
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="#top"><span class="logo-dot"></span> Artem Chernov</a>
+      <nav class="nav" aria-label="Навигация">
+        <button class="nav-toggle" aria-label="Меню" aria-expanded="false" aria-controls="mainNav"><span></span><span></span><span></span></button>
+        <ul class="nav-list" id="mainNav">
+          <li><a href="about.html">Обо мне</a></li>
+          <li><a href="#skills">Навыки</a></li>
+          <li><a href="#experience">Опыт</a></li>
+          <li><a href="#projects">Проекты</a></li>
+          <li><a href="#testimonials">Отзывы</a></li>
+          <li><a href="#contact">Контакты</a></li>
+          <li><button class="theme-toggle" id="themeToggle" aria-label="Сменить тему">🌓</button></li>
+        </ul>
+      </nav>
+    </div>
+    <div class="gradient"></div>
+  </header>
+
+  <!-- HERO: текст + фон-картинка на всю ширину -->
+  <section class="hero" id="top">
+    <div class="container hero-inner">
+      <div class="hero-text reveal">
+        <h1>Data Engineer <span class="accent">с фокусом на логистику и финансы</span></h1>
+        <p>Строю надёжные ETL/ELT-пайплайны, DWH и стриминг. Делаю наблюдаемость и тесты качества «по умолчанию», чтобы данные служили решению задач бизнеса — от CN→RU логистики до дивидендной аналитики.</p>
+        <div class="hero-cta">
+          <a class="btn primary" href="#projects">Смотреть проекты</a>
+          <a class="btn ghost" href="#contact">Связаться</a>
+        </div>
+        <div class="stats">
+          <div><strong>2–3 года</strong><span>продакшн-опыта</span></div>
+          <div><strong>CN→RU</strong><span>логистика, автоперевозки</span></div>
+          <div><strong>Fin</strong><span>дивиденды, отчётность</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="hero-bg">
+      <img src="../img/hero.png" alt="Данные и инфраструктура">
+    </div>
+  </section>
+
+  <!-- SKILLS -->
+  <section class="section container" id="skills">
+    <div class="section-header reveal">
+      <h2>Технологии и подходы</h2>
+      <p>Инструменты и практики, которыми пользуюсь ежедневно.</p>
+    </div>
+    <div class="skills reveal">
+      <span class="tag">Python</span>
+      <span class="tag">SQL (Postgres, ClickHouse)</span>
+      <span class="tag">Airflow / Prefect</span>
+      <span class="tag">Spark / PySpark</span>
+      <span class="tag">dbt Core</span>
+      <span class="tag">Kafka / Redpanda</span>
+      <span class="tag">S3 / MinIO</span>
+      <span class="tag">Docker</span>
+      <span class="tag">Metabase / Superset</span>
+      <span class="tag">GitHub Actions</span>
+      <span class="tag">Linux</span>
+      <span class="tag">RU / ZH / EN</span>
+    </div>
+  </section>
+
+  <!-- PROJECTS -->
+  <section class="section container" id="projects">
+    <div class="section-header reveal">
+      <h2>Выбранные проекты</h2>
+      <p>Кейсы, близкие моему домену. В модалке — детали архитектуры и эффекта.</p>
+    </div>
+
+    <div class="grid">
+      <article class="project reveal" data-modal="p1">
+        <img src="https://images.unsplash.com/photo-1526498460520-4c246339dccb?q=80&w=1200&auto=format&fit=crop" alt="Логистический стриминг" />
+        <div class="project-body">
+          <h3>Стриминг CN→RU: статусы грузов и SLA</h3>
+          <p>Собрали статусы грузов из китайских TMS/WMS и привели их к единому виду для SLA‑мониторинга. Дали бизнесу оперативную картину движения и сократили слепые зоны.</p>
+          <button class="btn small">Подробнее</button>
+        </div>
+      </article>
+
+      <article class="project reveal" data-modal="p2">
+        <img src="https://images.unsplash.com/photo-1487014679447-9f8336841d58?q=80&w=1200&auto=format&fit=crop" alt="Стоимость перевозки" />
+        <div class="project-body">
+          <h3>Калькулятор полной логистической стоимости</h3>
+          <p>Собрали в dbt расчёт полной логистической стоимости с учётом пошлин, СВХ и допработ. Результат — единая витрина расходов и быстрый расчёт без ручных ошибок.</p>
+          <button class="btn small">Подробнее</button>
+        </div>
+      </article>
+
+      <article class="project reveal" data-modal="p3">
+        <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?q=80&w=1200&auto=format&fit=crop" alt="Дивидендная аналитика" />
+        <div class="project-body">
+          <h3>Дивидендная аналитика (RU рынок)</h3>
+          <p>Автоматизировали ETL прайсов и календарей, привели отчётность МСФО/РСБУ к единому виду. Витрина выплат и реинвестов формируется за минуты вместо часов.</p>
+          <button class="btn small">Подробнее</button>
+        </div>
+      </article>
+
+      <article class="project reveal" data-modal="p4">
+        <img src="https://images.unsplash.com/photo-1518779578993-ec3579fee39f?q=80&w=1200&auto=format&fit=crop" alt="DQ/Observability" />
+        <div class="project-body">
+          <h3>Наблюдаемость и качество данных</h3>
+          <p>Внедрили SLI/SLA, тесты свежести и уникальности, пороговые алерты и трассировку. Это сократило MTTR и снизило число ложных тревог.</p>
+          <button class="btn small">Подробнее</button>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <!-- EXPERIENCE -->
+  <section id="experience" class="section container">
+    <div class="section-header reveal">
+      <h2>Опыт</h2>
+      <p>Ключевые вехи и проекты.</p>
+    </div>
+    <div class="timeline">
+      <article class="t-item reveal">
+        <div class="t-head">2024 — Наблюдаемость и качество данных</div>
+        <div class="t-body">
+          <ul>
+            <li>Внедрение SLI/SLA, тестов свежести и алертов</li>
+          </ul>
+        </div>
+      </article>
+      <article class="t-item reveal">
+        <div class="t-head">2023 — Стриминг CN→RU</div>
+        <div class="t-body">
+          <ul>
+            <li>Мониторинг статусов грузов в режиме реального времени</li>
+          </ul>
+        </div>
+      </article>
+      <article class="t-item reveal">
+        <div class="t-head">2022 — Калькулятор логистической стоимости</div>
+        <div class="t-body">
+          <ul>
+            <li>dbt-модели и витрины расходов</li>
+          </ul>
+        </div>
+      </article>
+      <article class="t-item reveal">
+        <div class="t-head">2021 — Дивидендная аналитика</div>
+        <div class="t-body">
+          <ul>
+            <li>ETL прайсов и автоматизированные дашборды</li>
+          </ul>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <!-- TESTIMONIALS -->
+  <section class="section container" id="testimonials">
+    <div class="section-header reveal">
+      <h2>Отзывы</h2>
+      <p>Реальные задачи, конкретные цифры и результат. Имена обезличены по NDA.</p>
+    </div>
+
+    <div class="testimonials">
+    <!-- Отзыв 1 -->
+    <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
+      <div class="quote-head">
+        <img class="avatar" src="https://images.unsplash.com/photo-1544005313-94ddf0286df2?q=80&w=400&auto=format&fit=crop" alt="Фото Ирины П." />
+        <div>
+          <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
+            <span itemprop="name">Ирина П.</span>
+          </strong>
+          <div class="meta">Директор по операционной логистике · маркетплейс (RU)</div>
+        </div>
+      </div>
+      <blockquote class="quote-text" itemprop="reviewBody" data-collapsed>
+        Мы пригласили Артёма для наведения порядка в потоке статусов CN→RU. За 4 недели он
+        подключил TMS/WMS поставщиков, привёл справочники к одному виду и внедрил SLA-мониторинг по плечам.
+        Доля «слепых зон» по статусам снизилась примерно на 70%, а штрафы за просрочки — на 18%.
+        Команда получила алерты и дашборды, которые действительно помогают в смене. Рекомендую за скорость,
+        аккуратную архитектуру и документацию.
+      </blockquote>
+      <ul class="facts">
+        <li>Срок внедрения: 4 недели</li>
+        <li>−70% слепых зон по статусам</li>
+        <li>−18% штрафов по SLA</li>
+      </ul>
+      <button class="more" aria-expanded="false">Читать полностью</button>
+      <meta itemprop="itemReviewed" content="Стриминг статусов и SLA" />
+      <meta itemprop="datePublished" content="2025-05-10" />
+    </figure>
+
+    <!-- Отзыв 2 -->
+    <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
+      <div class="quote-head">
+        <img class="avatar" src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?q=80&w=400&auto=format&fit=crop" alt="Фото Антона К." />
+        <div>
+          <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
+            <span itemprop="name">Антон К.</span>
+          </strong>
+          <div class="meta">Руководитель финансового блока · автoлогистика (CN→RU)</div>
+        </div>
+      </div>
+      <blockquote class="quote-text" itemprop="reviewBody" data-collapsed>
+        Артём перенёс наши расчёты полной стоимости перевозки в dbt: единые правила, тесты качества,
+        версия моделей и журнал изменений. Витрина теперь пересчитывается за секунды и легко сверяется с первичкой.
+        Ошибок в отчётности стало заметно меньше — по нашей оценке около 40%.
+      </blockquote>
+      <ul class="facts">
+        <li>dbt Core + Postgres/DuckDB</li>
+        <li>Время расчёта: секунды</li>
+        <li>Ошибки в отчётах: −40%</li>
+      </ul>
+      <button class="more" aria-expanded="false">Читать полностью</button>
+      <meta itemprop="itemReviewed" content="Калькулятор полной логистической стоимости" />
+      <meta itemprop="datePublished" content="2025-03-28" />
+    </figure>
+
+    <!-- Отзыв 3 -->
+    <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
+      <div class="quote-head">
+        <img class="avatar" src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?q=80&w=400&auto=format&fit=crop" alt="Фото Веры Л." />
+        <div>
+          <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
+            <span itemprop="name">Вера Л.</span>
+          </strong>
+          <div class="meta">Продуктовый аналитик · финтех-сервис</div>
+        </div>
+      </div>
+      <blockquote class="quote-text" itemprop="reviewBody" data-collapsed>
+        Мы делали витрину дивидендов и корпоративных действий. Артём настроил ETL календарей,
+        нормализацию МСФО/РСБУ и автоматический выпуск сводок в Telegram. Дашборды стали обновляться без ручных правок,
+        а команда редакции наконец получила один источник правды по выплатам и сезонности.
+      </blockquote>
+      <ul class="facts">
+        <li>Airflow + Parquet + Metabase</li>
+        <li>Автопостинг отчётов в Telegram</li>
+        <li>Один «источник правды» по дивидендам</li>
+      </ul>
+      <button class="more" aria-expanded="false">Читать полностью</button>
+      <meta itemprop="itemReviewed" content="Дивидендная аналитика" />
+      <meta itemprop="datePublished" content="2024-12-02" />
+    </figure>
+
+    <!-- Отзыв 4 -->
+    <figure class="quote reveal" itemscope itemtype="https://schema.org/Review">
+      <div class="quote-head">
+        <img class="avatar" src="https://images.unsplash.com/photo-1527980965255-d3b416303d12?q=80&w=400&auto=format&fit=crop" alt="Фото Дмитрия С." />
+        <div>
+          <strong itemprop="author" itemscope itemtype="https://schema.org/Person">
+            <span itemprop="name">Дмитрий С.</span>
+          </strong>
+          <div class="meta">Head of Data · e-commerce</div>
+        </div>
+      </div>
+      <blockquote class="quote-text" itemprop="reviewBody" data-collapsed>
+        В проекте наблюдаемости Артём внедрил тесты свежести/уникальности, SLI/SLA и алерты с порогами.
+        Ложных срабатываний стало меньше, MTTR упал примерно на треть. Понравилось, что всё сопровождается
+        документацией и читаемыми плейбуками для дежурных.
+      </blockquote>
+      <ul class="facts">
+        <li>Great Expectations / Soda + Prometheus/Grafana</li>
+        <li>MTTR ↓ ~35%</li>
+        <li>Меньше ложных алертов</li>
+      </ul>
+      <button class="more" aria-expanded="false">Читать полностью</button>
+      <meta itemprop="itemReviewed" content="Наблюдаемость пайплайнов" />
+      <meta itemprop="datePublished" content="2025-01-17" />
+    </figure>
+  </div>
+</section>
+
+  <!-- CONTACT -->
+  <section class="section container" id="contact">
+    <div class="section-header reveal">
+      <h2>Контакты</h2>
+    </div>
+
+    <div class="contact">
+      <div class="contact-card reveal">
+        <h3>Открыт к сотрудничеству</h3>
+        <p>Домены: логистика/склады, финансы/отчётность, контент-аналитика. Форматы — консалтинг, разработка, поддержка.</p>
+        <div class="contact-actions">
+          <a class="btn primary" href="mailto:83803087+JaevikSodertra@users.noreply.github.com">83803087+JaevikSodertra@users.noreply.github.com</a>
+          <a class="btn ghost" href="https://github.com/JaevikSodertra" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </div>
+        <p class="form-note">Языки: RU / ZH / EN / JP (базово).</p>
+      </div>
+
+      <form class="contact-form reveal" action="https://formspree.io/f/mwkgebkn" method="POST">
+        <label>Ваше имя <input required name="name" placeholder="Иван" /></label>
+        <label>Email <input type="email" required name="email" placeholder="name@mail.com" /></label>
+        <label>Сообщение <textarea required name="message" rows="4" placeholder="Нужно собрать витрину логистических затрат..." ></textarea></label>
+        <button class="btn primary" type="submit">Отправить</button>
+        <p class="form-note">* Для продакшн-формы позже подключим Formspree / любой бэкенд.</p>
+        <p class="form-status" hidden></p>
+      </form>
+    </div>
+  </section>
+
+  <!-- LATEST POSTS -->
+  <section class="section container" id="latest-posts">
+    <div class="section-header reveal">
+      <h2>Последние записи</h2>
+    </div>
+    <ul class="latest-posts">
+      {% assign posts = site.pages | where_exp: 'p', "p.path contains 'posts/'" | sort: 'date' | reverse %}
+      {% for post in posts limit: 3 %}
+      <li><a href="{{ post.url }}">{{ post.title }}</a> <span>{{ post.date | date: "%d.%m.%Y" }}</span></li>
+      {% endfor %}
+    </ul>
+    <div class="latest-links">
+      <a href="/blog.html">Все записи</a> · <a href="/feed.xml">RSS</a>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <span>© <span id="year"></span> Artem Chernov · Data Engineer</span>
+      <a href="#top" class="to-top" aria-label="Наверх">↑ Наверх</a>
+    </div>
+  </footer>
+
+  <!-- Модальные окна проектов -->
+  <div class="modal" id="p1" aria-hidden="true" role="dialog" aria-modal="true">
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Закрыть">×</button>
+      <h3>Стриминг CN→RU: статусы грузов и SLA</h3>
+      <p>Источники: китайские TMS/WMS (webhooks + периодический polling). Нормализация справочников, дедупликация по composite-key, маршрутизация в топики Kafka. Оркестрация в Airflow, слой <em>staging → marts</em> в ClickHouse.</p>
+      <ul class="metrics">
+        <li>Снижение «слепых зон» по статусам ~70%</li>
+        <li>Алерты по SLA: −18% штрафов</li>
+        <li>Событие появлялось в аналитике через минуты</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="modal" id="p2" aria-hidden="true" role="dialog" aria-modal="true">
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Закрыть">×</button>
+      <h3>Калькулятор полной логистической стоимости</h3>
+      <p>dbt-модели с тестами и версионированием. Витрина учитывает пошлины, СВХ, брокераж, утилизацию, доп-работы (оклейка, дооснащение). Единые правила расчёта + журнал изменений.</p>
+      <ul class="metrics">
+        <li>Ошибки в отчётности −40%</li>
+        <li>Время расчёта — секунды</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="modal" id="p3" aria-hidden="true" role="dialog" aria-modal="true">
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Закрыть">×</button>
+      <h3>Дивидендная аналитика (RU рынок)</h3>
+      <p>ETL календарей и прайсов в Airflow, нормализация МСФО/РСБУ, расчёт DY, payout ratio и сезонности. Дашборды в Metabase и автопостинг сводок в Telegram.</p>
+      <ul class="metrics">
+        <li>Время подготовки отчётов ↓ с 2 ч до 15 мин</li>
+        <li>Погрешность расчётов <1%</li>
+        <li>Покрытие рынка дивидендов >95%</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="modal" id="p4" aria-hidden="true" role="dialog" aria-modal="true">
+    <div class="modal__dialog">
+      <button class="modal__close" data-close aria-label="Закрыть">×</button>
+      <h3>Наблюдаемость и качество данных</h3>
+      <p>SLI/SLA, тесты свежести и уникальности, пороговые алерты и trace-логирование. Стек: Great Expectations, Soda, Prometheus, Grafana. Бейзлайны по сезонности для снижения ложных тревог.</p>
+      <ul class="metrics">
+        <li>MTTR ↓ ~35%</li>
+        <li>Ложные алерты −50%</li>
+        <li>Покрытие критичных пайплайнов 100%</li>
+      </ul>
+    </div>
+  </div>
+
+  <script src="../js/app.js" defer></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add index page under pages with correct asset paths
- update about page to reference assets via ../css, ../js, and ../img

## Testing
- `python - <<'PY'
import html.parser
for path in ['pages/index.html','pages/about.html']:
    html.parser.HTMLParser().feed(open(path, encoding='utf-8').read())
print('parsed ok')
PY`
- `npx htmlhint pages/index.html pages/about.html` (command not found)
- `tidy -q -e pages/index.html` (command not found)
- `apt-get update` (403: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68bd8352db7c83228bdb722a3b26805f