### PR TITLE
Fix About page image reference

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -36,7 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
-      <img src="img/me.jpg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
+      <img src="../img/hero.png" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 


### PR DESCRIPTION
## Summary
- use existing hero.png image on the About page so the picture loads

## Testing
- `curl -I http://localhost:8000/pages/about.html`
- `curl -I http://localhost:8000/img/hero.png`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd83f433f083229d117f3b6a047072