### PR TITLE
Fix about page links

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <nav class="nav" aria-label="Навигация">
         <button class="nav-toggle" aria-label="Меню" aria-expanded="false"><span></span><span></span><span></span></button>
         <ul class="nav-list">
-          <li><a href="about.html">Обо мне</a></li>
+          <li><a href="pages/about.html">Обо мне</a></li>
           <li><a href="#skills">Навыки</a></li>
           <li><a href="#projects">Проекты</a></li>
           <li><a href="#testimonials">Отзывы</a></li>
@@ -89,7 +89,7 @@
         <div class="project-body">
           <h3>Стриминг CN→RU: статусы и SLA</h3>
           <p>Подключили TMS/WMS, нормализовали статусы, SLA-мониторинг. ↓ слепых зон ≈70%, ↓ штрафов 18%.</p>
-          <a class="btn small" href="about.html#p1">Подробнее</a>
+          <a class="btn small" href="pages/about.html#p1">Подробнее</a>
         </div>
       </article>
 
@@ -98,7 +98,7 @@
         <div class="project-body">
           <h3>Полная логистическая стоимость</h3>
           <p>dbt-правила и тесты, единая витрина расходов. Рассчёт — секунды, ошибок меньше ≈40%.</p>
-          <a class="btn small" href="about.html#p2">Подробнее</a>
+          <a class="btn small" href="pages/about.html#p2">Подробнее</a>
         </div>
       </article>
 
@@ -107,7 +107,7 @@
         <div class="project-body">
           <h3>Дивидендная аналитика</h3>
           <p>ETL календарей/прайсов, нормализация МСФО/РСБУ, телеграм-сводки. Один источник правды.</p>
-          <a class="btn small" href="about.html#p3">Подробнее</a>
+          <a class="btn small" href="pages/about.html#p3">Подробнее</a>
         </div>
       </article>
 
@@ -116,7 +116,7 @@
         <div class="project-body">
           <h3>Наблюдаемость и качество</h3>
           <p>SLI/SLA, freshness/uniqueness, алерты. MTTR ↓ ~35%, меньше ложных тревог.</p>
-          <a class="btn small" href="about.html#p4">Подробнее</a>
+          <a class="btn small" href="pages/about.html#p4">Подробнее</a>
         </div>
       </article>
     </div>


### PR DESCRIPTION
## Summary
- update index links to point to pages/about.html

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `curl http://localhost:8000/index.html | rg 'pages/about.html'`
- `curl http://localhost:8000/pages/about.html | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68bd87bd26b48322ae91ba6421706c2b