### PR TITLE
Inline placeholder images to fix broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
 
     <div class="grid">
       <article class="project reveal">
-        <img src="img/p1.png" alt="Стриминг статусов CN→RU">
+        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Стриминг статусов CN→RU">
         <div class="project-body">
           <h3>Стриминг CN→RU: статусы и SLA</h3>
           <p>Подключили TMS/WMS, нормализовали статусы, SLA-мониторинг. ↓ слепых зон ≈70%, ↓ штрафов 18%.</p>
@@ -94,7 +94,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="img/p2.png" alt="Калькулятор логистической стоимости">
+        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Калькулятор логистической стоимости">
         <div class="project-body">
           <h3>Полная логистическая стоимость</h3>
           <p>dbt-правила и тесты, единая витрина расходов. Рассчёт — секунды, ошибок меньше ≈40%.</p>
@@ -103,7 +103,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="img/p3.png" alt="Дивидендная аналитика">
+        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Дивидендная аналитика">
         <div class="project-body">
           <h3>Дивидендная аналитика</h3>
           <p>ETL календарей/прайсов, нормализация МСФО/РСБУ, телеграм-сводки. Один источник правды.</p>
@@ -112,7 +112,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="img/p4.png" alt="Наблюдаемость данных">
+        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Наблюдаемость данных">
         <div class="project-body">
           <h3>Наблюдаемость и качество</h3>
           <p>SLI/SLA, freshness/uniqueness, алерты. MTTR ↓ ~35%, меньше ложных тревог.</p>
@@ -131,7 +131,7 @@
 
     <div class="testimonials">
       <figure class="quote reveal">
-        <img class="avatar" src="img/ava1.jpg" alt="">
+        <img class="avatar" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="">
         <blockquote class="quote-text">
           «За 4 недели Артём подключил наши TMS/WMS и навёл порядок в статусах. Слепые зоны по маршрутам заметно сократились,
           а штрафы за просрочки снизились. Дашборды и алерты реально помогают в смене.»
@@ -140,7 +140,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="img/ava2.jpg" alt="">
+        <img class="avatar" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="">
         <blockquote class="quote-text">
           «Перенёс расчёты полной стоимости в dbt с тестами и версионированием. Теперь считаем быстро и прозрачно,
           ошибки в отчётности сократились примерно на 40%.»
@@ -149,7 +149,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="img/ava3.jpg" alt="">
+        <img class="avatar" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="">
         <blockquote class="quote-text">
           «Витрина дивидендов перестала требовать ручных правок, отчёты уходят автоматически. Наконец-то один источник правды.»
         </blockquote>

--- a/pages/about.html
+++ b/pages/about.html
@@ -36,7 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
-      <img src="../img/me.jpg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
+      <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 


### PR DESCRIPTION
## Summary
- Remove previously added binary placeholder files
- Replace project, testimonial, and profile images with inline 1x1 GIF data URIs to avoid broken image icons

## Testing
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/pages/about.html`
- `curl -I http://localhost:8000/img/hero.png`
- `curl -I http://localhost:8000/img/chain.png`


------
https://chatgpt.com/codex/tasks/task_e_68bd89a89be88322a14a95201bd19136