### PR TITLE
Add form status element to contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
         <label>Email <input type="email" required name="email" placeholder="name@mail.com" /></label>
         <label>Сообщение <textarea required name="message" rows="4" placeholder="Опишите задачу..." ></textarea></label>
         <button class="btn primary" type="submit">Отправить</button>
+        <p class="form-status" hidden></p>
       </form>
     </div>
   </section>

--- a/js/app.js
+++ b/js/app.js
@@ -79,6 +79,7 @@ const contactForm = document.querySelector('.contact-form');
 contactForm?.addEventListener('submit', async (e) => {
   e.preventDefault();
   const statusEl = contactForm.querySelector('.form-status');
+  if (!statusEl) return;
   statusEl.hidden = true;
   const data = new FormData(contactForm);
   try {


### PR DESCRIPTION
## Summary
- add a hidden form status paragraph after the contact form submit button
- guard the contact form script so it safely updates success and error messages

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c927bb83cc8322972bdfefca9aa28a