### PR TITLE
Style features cards layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,6 +77,22 @@ p{margin:0 0 16px;max-width:70ch} ul,li{margin:0 0 8px 20px;padding:0}
 .section-header{margin-bottom:28px}
 .section-header p{color:var(--muted);margin:0}
 
+.features{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:18px;
+  align-items:stretch;
+}
+
+.card{
+  padding:18px;
+  border:1px solid var(--border);
+  border-radius:var(--radius);
+  background:var(--panel);
+  backdrop-filter:blur(8px);
+  box-shadow:var(--shadow);
+}
+
 .about-photo{
   width:200px;
   height:auto;


### PR DESCRIPTION
## Summary
- add a responsive grid layout to the `.features` wrapper used on the about page
- style feature cards with padding, borders, and panel backgrounds to match the existing aesthetic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c927bc3e9883228b36d6f30ab42724