### PR TITLE
Extract inline SVG assets

### DIFF
--- a/img/data-flow.svg
+++ b/img/data-flow.svg
@@ -1,0 +1,1 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='#00d4ff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M10 13a5 5 0 006.3.8l3-3a5 5 0 00-7.1-7.1l-1.5 1.5'/><path d='M14 11a5 5 0 00-6.3-.8l-3 3a5 5 0 007.1 7.1l1.5-1.5'/></svg>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
 
     <div class="grid">
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Стриминг статусов CN→RU">
+        <img src="img/data-flow.svg" alt="Стриминг статусов CN→RU">
         <div class="project-body">
           <h3>Стриминг CN→RU: статусы и SLA</h3>
           <p>Подключили TMS/WMS, нормализовали статусы, SLA-мониторинг. ↓ слепых зон ≈70%, ↓ штрафов 18%.</p>
@@ -94,7 +94,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Калькулятор логистической стоимости">
+        <img src="img/data-flow.svg" alt="Калькулятор логистической стоимости">
         <div class="project-body">
           <h3>Полная логистическая стоимость</h3>
           <p>dbt-правила и тесты, единая витрина расходов. Рассчёт — секунды, ошибок меньше ≈40%.</p>
@@ -103,7 +103,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Дивидендная аналитика">
+        <img src="img/data-flow.svg" alt="Дивидендная аналитика">
         <div class="project-body">
           <h3>Дивидендная аналитика</h3>
           <p>ETL календарей/прайсов, нормализация МСФО/РСБУ, телеграм-сводки. Один источник правды.</p>
@@ -112,7 +112,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Наблюдаемость данных">
+        <img src="img/data-flow.svg" alt="Наблюдаемость данных">
         <div class="project-body">
           <h3>Наблюдаемость и качество</h3>
           <p>SLI/SLA, freshness/uniqueness, алерты. MTTR ↓ ~35%, меньше ложных тревог.</p>
@@ -131,7 +131,7 @@
 
     <div class="testimonials">
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="">
+        <img class="avatar" src="img/data-flow.svg" alt="">
         <blockquote class="quote-text">
           «За 4 недели Артём подключил наши TMS/WMS и навёл порядок в статусах. Слепые зоны по маршрутам заметно сократились,
           а штрафы за просрочки снизились. Дашборды и алерты реально помогают в смене.»
@@ -140,7 +140,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="">
+        <img class="avatar" src="img/data-flow.svg" alt="">
         <blockquote class="quote-text">
           «Перенёс расчёты полной стоимости в dbt с тестами и версионированием. Теперь считаем быстро и прозрачно,
           ошибки в отчётности сократились примерно на 40%.»
@@ -149,7 +149,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="">
+        <img class="avatar" src="img/data-flow.svg" alt="">
         <blockquote class="quote-text">
           «Витрина дивидендов перестала требовать ручных правок, отчёты уходят автоматически. Наконец-то один источник правды.»
         </blockquote>


### PR DESCRIPTION
## Summary
- decode the repeated inline SVG data URI and save it as img/data-flow.svg
- point project and testimonial images to the shared SVG asset so browsers can cache it

## Testing
- python -m http.server 8000 (manual verification in browser)


------
https://chatgpt.com/codex/tasks/task_e_68c927bfd6b8832283c8467502a3eedb