### PR TITLE
Add external light-friendly favicon

### DIFF
--- a/img/favicon.svg
+++ b/img/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="badgeGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#00c7f2" />
+      <stop offset="100%" stop-color="#0095d5" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#f7fbff" stroke="url(#badgeGradient)" stroke-width="4" />
+  <path d="M23 41.5h-6.4l-1.5 4.4h-5L18.4 18h6.2l8.2 27.9h-5.3l-1.5-4.4zm-5.2-4.3h4l-1.9-6.3c-.5-1.7-.9-3.3-1.3-5-.4 1.7-.8 3.3-1.3 5l-1.9 6.3z" fill="#00334f" />
+  <path d="M34.5 22h9.5c6 0 9.6 3.3 9.6 8.8s-3.6 8.9-9.6 8.9h-4.3v6.2h-5.2V22zm8.9 12.9c2.9 0 4.4-1.4 4.4-4.1s-1.5-4.1-4.4-4.1h-3.7v8.2h3.7z" fill="#00334f" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Artem Chernov — Data Engineer</title>
   <meta name="description" content="Data Engineer: ETL/ELT, стриминг, DWH, наблюдаемость. Логистика CN→RU и финансы." />
   <!-- Иконка -->
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect rx='22' ry='22' x='4' y='4' width='92' height='92' fill='%2300d4ff'/%3E%3Ctext x='50' y='62' font-size='50' text-anchor='middle' fill='white' font-family='Arial'%3EDE%3C/text%3E%3C/svg%3E">
+  <link rel="icon" type="image/svg+xml" href="img/favicon.svg" />
   <!-- Шрифты -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <!-- Стили -->


### PR DESCRIPTION
## Summary
- add a standalone SVG favicon optimised for light backgrounds
- update the HTML head to reference the exported icon instead of an inline data URI

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68c92b3541ec8322adcedf31ff6f8eae