### PR TITLE
Set default theme to light by default

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 // Тема
 const themeToggle = document.getElementById('themeToggle');
 const saved = localStorage.getItem('theme');
-const initial = saved ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+const initial = saved ?? 'light';
 document.documentElement.setAttribute('data-theme', initial);
 themeToggle?.addEventListener('click', () => {
   const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'dark' : 'light';


### PR DESCRIPTION
## Summary
- default the stored theme to light when no saved preference exists

## Testing
- Manually cleared localStorage, reloaded the page, and confirmed the light theme is applied despite dark OS preference

------
https://chatgpt.com/codex/tasks/task_e_68c92b32d2c08322926c03fda57e9724