### PR TITLE
Replace inline SVGs with darker standalone assets

### DIFF
--- a/img/avatar-analytics.svg
+++ b/img/avatar-analytics.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Аватар для продуктового аналитика</title>
+  <desc id="desc">Силуэт человека на зелёном фоне с диаграммой</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="32" r="26" fill="#e3f9ef" />
+    <circle cx="32" cy="24" r="8" fill="#ffffff" />
+    <path d="M24 44h16l4 10H20z" fill="#ffffff" />
+    <path d="M24 46l4 -4 4 3 6 -7" />
+  </g>
+</svg>

--- a/img/avatar-analytics.svg
+++ b/img/avatar-analytics.svg
@@ -1,10 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Аватар для продуктового аналитика</title>
-  <desc id="desc">Силуэт человека на зелёном фоне с диаграммой</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="avatar-analytics-title avatar-analytics-desc">
+  <title id="avatar-analytics-title">Аватар для продуктового аналитика</title>
+  <desc id="avatar-analytics-desc">Силуэт человека с диаграммой на зелёном фоне</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <circle cx="32" cy="32" r="26" fill="#e3f9ef" />
+    <circle cx="32" cy="32" r="26" fill="#e2f8f0" />
     <circle cx="32" cy="24" r="8" fill="#ffffff" />
     <path d="M24 44h16l4 10H20z" fill="#ffffff" />
-    <path d="M24 46l4 -4 4 3 6 -7" />
+    <path d="M40 46l8 -8" />
+    <path d="M44 38v6h-6" />
+    <path d="M20 52l-6 4" />
+    <path d="M44 52l6 4" />
   </g>
 </svg>

--- a/img/avatar-finance.svg
+++ b/img/avatar-finance.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Аватар для руководителя финблока</title>
+  <desc id="desc">Силуэт человека на холодном фоне с галстуком</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="32" r="26" fill="#e3f1ff" />
+    <circle cx="32" cy="23" r="8" fill="#ffffff" />
+    <path d="M22 46c3 -6 17 -6 20 0l-4 8h-12z" fill="#ffffff" />
+    <path d="M32 34l-3 6 3 2 3 -2z" fill="#ffffff" />
+  </g>
+</svg>

--- a/img/avatar-finance.svg
+++ b/img/avatar-finance.svg
@@ -1,10 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Аватар для руководителя финблока</title>
-  <desc id="desc">Силуэт человека на холодном фоне с галстуком</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="avatar-finance-title avatar-finance-desc">
+  <title id="avatar-finance-title">Аватар для руководителя финблока</title>
+  <desc id="avatar-finance-desc">Силуэт человека с галстуком и монетой на холодном фоне</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <circle cx="32" cy="32" r="26" fill="#e3f1ff" />
+    <circle cx="32" cy="32" r="26" fill="#e6f0ff" />
     <circle cx="32" cy="23" r="8" fill="#ffffff" />
     <path d="M22 46c3 -6 17 -6 20 0l-4 8h-12z" fill="#ffffff" />
     <path d="M32 34l-3 6 3 2 3 -2z" fill="#ffffff" />
+    <circle cx="46" cy="44" r="6" fill="#e0ebff" />
+    <path d="M46 40v8m-3 -3h4" />
   </g>
 </svg>

--- a/img/avatar-logistics.svg
+++ b/img/avatar-logistics.svg
@@ -1,9 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Аватар для директора по операционной логистике</title>
-  <desc id="desc">Силуэт человека на фоне тёплого круга</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="avatar-logistics-title avatar-logistics-desc">
+  <title id="avatar-logistics-title">Аватар для директора по операционной логистике</title>
+  <desc id="avatar-logistics-desc">Силуэт человека с маршрутной стрелкой на тёплом фоне</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <circle cx="32" cy="32" r="26" fill="#fdf4d9" />
+    <circle cx="32" cy="32" r="26" fill="#fdf1dd" />
     <circle cx="32" cy="24" r="8" fill="#ffffff" />
     <path d="M20 46a12 12 0 0 1 24 0v6H20z" fill="#ffffff" />
+    <path d="M20 52l-6 4" />
+    <path d="M44 52l6 4" />
+    <path d="M18 34h10l4 -4 6 6 8 -4" />
+    <path d="M46 32l4 2-4 2z" fill="#1b2f45" stroke="#1b2f45" />
   </g>
 </svg>

--- a/img/avatar-logistics.svg
+++ b/img/avatar-logistics.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Аватар для директора по операционной логистике</title>
+  <desc id="desc">Силуэт человека на фоне тёплого круга</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="32" r="26" fill="#fdf4d9" />
+    <circle cx="32" cy="24" r="8" fill="#ffffff" />
+    <path d="M20 46a12 12 0 0 1 24 0v6H20z" fill="#ffffff" />
+  </g>
+</svg>

--- a/img/favicon.svg
+++ b/img/favicon.svg
@@ -1,12 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <rect x="8" y="8" width="84" height="84" rx="20" fill="#f3f7fb" stroke="#1b2f45" stroke-width="6" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-labelledby="favicon-title favicon-desc">
+  <title id="favicon-title">Favicon: схема потоков данных</title>
+  <desc id="favicon-desc">Соединённые узлы в виде диаграммы с направленной стрелкой</desc>
+  <rect x="8" y="8" width="84" height="84" rx="20" fill="#f2f6fb" stroke="#1b2f45" stroke-width="6" />
   <g fill="none" stroke="#1b2f45" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M28 36h24l8 12 12 -12" />
-    <path d="M28 64h44" />
+    <path d="M26 36h26l10 14 12 -14" />
+    <path d="M26 68h48" />
   </g>
-  <circle cx="28" cy="36" r="5" fill="#1b2f45" />
-  <circle cx="60" cy="48" r="5" fill="#1b2f45" />
-  <circle cx="84" cy="36" r="5" fill="#1b2f45" />
-  <circle cx="28" cy="64" r="5" fill="#1b2f45" />
-  <circle cx="72" cy="64" r="5" fill="#1b2f45" />
+  <g fill="#1b2f45">
+    <circle cx="26" cy="36" r="5" />
+    <circle cx="52" cy="50" r="5" />
+    <circle cx="74" cy="36" r="5" />
+    <circle cx="26" cy="68" r="5" />
+    <circle cx="74" cy="68" r="5" />
+  </g>
 </svg>

--- a/img/favicon.svg
+++ b/img/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="8" y="8" width="84" height="84" rx="20" fill="#f3f7fb" stroke="#1b2f45" stroke-width="6" />
+  <g fill="none" stroke="#1b2f45" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M28 36h24l8 12 12 -12" />
+    <path d="M28 64h44" />
+  </g>
+  <circle cx="28" cy="36" r="5" fill="#1b2f45" />
+  <circle cx="60" cy="48" r="5" fill="#1b2f45" />
+  <circle cx="84" cy="36" r="5" fill="#1b2f45" />
+  <circle cx="28" cy="64" r="5" fill="#1b2f45" />
+  <circle cx="72" cy="64" r="5" fill="#1b2f45" />
+</svg>

--- a/img/favicon.svg
+++ b/img/favicon.svg
@@ -1,16 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-labelledby="favicon-title favicon-desc">
-  <title id="favicon-title">Favicon: схема потоков данных</title>
-  <desc id="favicon-desc">Соединённые узлы в виде диаграммы с направленной стрелкой</desc>
-  <rect x="8" y="8" width="84" height="84" rx="20" fill="#f2f6fb" stroke="#1b2f45" stroke-width="6" />
-  <g fill="none" stroke="#1b2f45" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M26 36h26l10 14 12 -14" />
-    <path d="M26 68h48" />
-  </g>
-  <g fill="#1b2f45">
-    <circle cx="26" cy="36" r="5" />
-    <circle cx="52" cy="50" r="5" />
-    <circle cx="74" cy="36" r="5" />
-    <circle cx="26" cy="68" r="5" />
-    <circle cx="74" cy="68" r="5" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="favicon-title favicon-desc">
+  <title id="favicon-title">Favicon: эмблема Data Engineer</title>
+  <desc id="favicon-desc">Значок с градиентной рамкой и монограммой DE</desc>
+  <defs>
+    <linearGradient id="badgeGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#00c7f2" />
+      <stop offset="100%" stop-color="#0095d5" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#f7fbff" stroke="url(#badgeGradient)" stroke-width="4" />
+  <path d="M23 41.5h-6.4l-1.5 4.4h-5L18.4 18h6.2l8.2 27.9h-5.3l-1.5-4.4zm-5.2-4.3h4l-1.9-6.3c-.5-1.7-.9-3.3-1.3-5-.4 1.7-.8 3.3-1.3 5l-1.9 6.3z" fill="#00334f" />
+  <path d="M34.5 22h9.5c6 0 9.6 3.3 9.6 8.8s-3.6 8.9-9.6 8.9h-4.3v6.2h-5.2V22zm8.9 12.9c2.9 0 4.4-1.4 4.4-4.1s-1.5-4.1-4.4-4.1h-3.7v8.2h3.7z" fill="#00334f" />
 </svg>

--- a/img/project-dividends.svg
+++ b/img/project-dividends.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Иконка проекта дивидендной аналитики</title>
+  <desc id="desc">Столбчатый график с растущей стрелкой и монетами</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="10" y="30" width="10" height="20" rx="2" fill="#f1f7ff" />
+    <rect x="24" y="22" width="10" height="28" rx="2" fill="#f1f7ff" />
+    <rect x="38" y="16" width="10" height="34" rx="2" fill="#f1f7ff" />
+    <path d="M10 50h38" />
+    <path d="M12 36l12 -10 10 8 14 -16" />
+    <path d="M44 18h10M54 18l-4 -4M54 18l-4 4" />
+    <circle cx="22" cy="52" r="4" fill="#e6f4ff" />
+    <circle cx="34" cy="52" r="4" fill="#e6f4ff" />
+    <path d="M22 50v4m-2 -2h4" />
+    <path d="M34 50v4m-2 -2h4" />
+  </g>
+</svg>

--- a/img/project-dividends.svg
+++ b/img/project-dividends.svg
@@ -1,15 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Иконка проекта дивидендной аналитики</title>
-  <desc id="desc">Столбчатый график с растущей стрелкой и монетами</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="project-dividends-title project-dividends-desc">
+  <title id="project-dividends-title">Иконка проекта дивидендной аналитики</title>
+  <desc id="project-dividends-desc">Столбчатый график со стрелкой роста и монетами</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <rect x="10" y="30" width="10" height="20" rx="2" fill="#f1f7ff" />
-    <rect x="24" y="22" width="10" height="28" rx="2" fill="#f1f7ff" />
-    <rect x="38" y="16" width="10" height="34" rx="2" fill="#f1f7ff" />
-    <path d="M10 50h38" />
+    <rect x="10" y="30" width="10" height="20" rx="2.5" fill="#e7f0ff" />
+    <rect x="24" y="22" width="10" height="28" rx="2.5" fill="#e7f0ff" />
+    <rect x="38" y="16" width="10" height="34" rx="2.5" fill="#e7f0ff" />
+    <path d="M10 50h44" />
     <path d="M12 36l12 -10 10 8 14 -16" />
-    <path d="M44 18h10M54 18l-4 -4M54 18l-4 4" />
-    <circle cx="22" cy="52" r="4" fill="#e6f4ff" />
-    <circle cx="34" cy="52" r="4" fill="#e6f4ff" />
+    <path d="M48 18h8m0 0l-4 -4m4 4l-4 4" />
+    <circle cx="22" cy="52" r="4" fill="#f1f7ff" />
+    <circle cx="34" cy="52" r="4" fill="#f1f7ff" />
     <path d="M22 50v4m-2 -2h4" />
     <path d="M34 50v4m-2 -2h4" />
   </g>

--- a/img/project-logistics-cost.svg
+++ b/img/project-logistics-cost.svg
@@ -1,12 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Иконка проекта полной логистической стоимости</title>
-  <desc id="desc">Документ с метками стоимости и монетой</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="project-logistics-cost-title project-logistics-cost-desc">
+  <title id="project-logistics-cost-title">Иконка проекта полной логистической стоимости</title>
+  <desc id="project-logistics-cost-desc">Документ с метками стоимости и монетой</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M22 10h18l12 12v26a10 10 0 0 1 -10 10H22a10 10 0 0 1 -10 -10V20a10 10 0 0 1 10 -10z" fill="#f5f8fc" />
-    <path d="M40 10v12h12" />
-    <path d="M20 28h16M20 36h10" />
-    <circle cx="40" cy="44" r="10" fill="#e2f0ff" />
-    <path d="M40 37v14m-5 -6h7a3.5 3.5 0 0 0 0 -7h-5" />
-    <path d="M26 46h-8l4 6" />
+    <path d="M20 8h20l12 12v26a12 12 0 0 1 -12 12H20a12 12 0 0 1 -12 -12V20a12 12 0 0 1 12 -12z" fill="#f3f6fb" />
+    <path d="M40 8v12h12" />
+    <path d="M20 26h16M20 34h12" />
+    <path d="M20 42h12" stroke-dasharray="4 4" />
+    <circle cx="42" cy="46" r="10" fill="#e2efff" />
+    <path d="M42 38v16m-6 -6h8a3.5 3.5 0 0 0 0 -7h-5" />
+    <path d="M24 52l-6 4" />
+    <path d="M28 52l6 4" />
   </g>
 </svg>

--- a/img/project-logistics-cost.svg
+++ b/img/project-logistics-cost.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Иконка проекта полной логистической стоимости</title>
+  <desc id="desc">Документ с метками стоимости и монетой</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M22 10h18l12 12v26a10 10 0 0 1 -10 10H22a10 10 0 0 1 -10 -10V20a10 10 0 0 1 10 -10z" fill="#f5f8fc" />
+    <path d="M40 10v12h12" />
+    <path d="M20 28h16M20 36h10" />
+    <circle cx="40" cy="44" r="10" fill="#e2f0ff" />
+    <path d="M40 37v14m-5 -6h7a3.5 3.5 0 0 0 0 -7h-5" />
+    <path d="M26 46h-8l4 6" />
+  </g>
+</svg>

--- a/img/project-observability.svg
+++ b/img/project-observability.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Иконка проекта наблюдаемости</title>
+  <desc id="desc">Радар с индикатором и контурами сигналов</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="32" r="22" fill="#f3f7fb" />
+    <circle cx="32" cy="32" r="10" />
+    <path d="M32 20v-6m0 36v-6" />
+    <path d="M20 32h-6m36 0h-6" />
+    <path d="M32 32l10 -6" />
+    <circle cx="42" cy="26" r="3" fill="#1b2f45" />
+    <path d="M16 18a22 22 0 0 1 28 -4M20 46a22 22 0 0 0 28 -4" />
+    <path d="M14 50h12l-3 8m20 -8h12l-3 8" />
+  </g>
+</svg>

--- a/img/project-observability.svg
+++ b/img/project-observability.svg
@@ -1,14 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Иконка проекта наблюдаемости</title>
-  <desc id="desc">Радар с индикатором и контурами сигналов</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="project-observability-title project-observability-desc">
+  <title id="project-observability-title">Иконка проекта наблюдаемости</title>
+  <desc id="project-observability-desc">Радар с индикатором и контрольными дугами</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <circle cx="32" cy="32" r="22" fill="#f3f7fb" />
+    <circle cx="32" cy="32" r="22" fill="#f0f5fc" />
     <circle cx="32" cy="32" r="10" />
     <path d="M32 20v-6m0 36v-6" />
     <path d="M20 32h-6m36 0h-6" />
-    <path d="M32 32l10 -6" />
-    <circle cx="42" cy="26" r="3" fill="#1b2f45" />
-    <path d="M16 18a22 22 0 0 1 28 -4M20 46a22 22 0 0 0 28 -4" />
-    <path d="M14 50h12l-3 8m20 -8h12l-3 8" />
+    <path d="M32 32l12 -7" />
+    <circle cx="44" cy="25" r="3.5" fill="#1b2f45" />
+    <path d="M16 18a24 24 0 0 1 32 0" />
+    <path d="M16 46a24 24 0 0 0 32 0" />
+    <path d="M14 50h14l-3 8m18 -8h14l-3 8" />
   </g>
 </svg>

--- a/img/project-streaming.svg
+++ b/img/project-streaming.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Иконка проекта стриминга статусов</title>
+  <desc id="desc">Соединённые узлы с направленным потоком из Китая в Россию</desc>
+  <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="6" y="22" width="18" height="16" rx="3.5" fill="#f4f8fc" />
+    <rect x="40" y="22" width="18" height="16" rx="3.5" fill="#f4f8fc" />
+    <path d="M24 30h12" />
+    <path d="M35 26l7 4 -7 4z" fill="#1b2f45" stroke="#1b2f45" />
+    <circle cx="32" cy="30" r="3" fill="#1b2f45" />
+    <path d="M12 27h9M12 32h9" />
+    <path d="M46 27h6M46 32h6" />
+    <path d="M22 17a14 14 0 0 1 20 0" />
+    <path d="M42 43a14 14 0 0 1 -20 0" />
+    <path d="M18 44l-8 8" />
+    <path d="M46 20l8 -8" />
+  </g>
+</svg>

--- a/img/project-streaming.svg
+++ b/img/project-streaming.svg
@@ -1,17 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Иконка проекта стриминга статусов</title>
-  <desc id="desc">Соединённые узлы с направленным потоком из Китая в Россию</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="project-streaming-title project-streaming-desc">
+  <title id="project-streaming-title">Иконка проекта стриминга статусов</title>
+  <desc id="project-streaming-desc">Поток данных между двумя узлами с отметкой маршрута</desc>
   <g fill="none" stroke="#1b2f45" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <rect x="6" y="22" width="18" height="16" rx="3.5" fill="#f4f8fc" />
-    <rect x="40" y="22" width="18" height="16" rx="3.5" fill="#f4f8fc" />
-    <path d="M24 30h12" />
-    <path d="M35 26l7 4 -7 4z" fill="#1b2f45" stroke="#1b2f45" />
-    <circle cx="32" cy="30" r="3" fill="#1b2f45" />
-    <path d="M12 27h9M12 32h9" />
-    <path d="M46 27h6M46 32h6" />
-    <path d="M22 17a14 14 0 0 1 20 0" />
-    <path d="M42 43a14 14 0 0 1 -20 0" />
-    <path d="M18 44l-8 8" />
-    <path d="M46 20l8 -8" />
+    <rect x="6" y="16" width="52" height="32" rx="9" fill="#f2f6fb" />
+    <rect x="12" y="22" width="10" height="20" rx="3" fill="#ffffff" />
+    <rect x="42" y="22" width="10" height="20" rx="3" fill="#ffffff" />
+    <path d="M22 32h12" />
+    <path d="M34 27l10 5-10 5z" fill="#1b2f45" stroke="#1b2f45" />
+    <circle cx="18" cy="24" r="3" fill="#e1ecfb" />
+    <circle cx="48" cy="36" r="3" fill="#e1ecfb" />
+    <path d="M14 24h-4m0 16h6" />
+    <path d="M50 24h4m0 16h-6" />
+    <path d="M16 18a24 24 0 0 1 32 0" />
+    <path d="M16 46a24 24 0 0 0 32 0" />
   </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Artem Chernov — Data Engineer</title>
   <meta name="description" content="Data Engineer: ETL/ELT, стриминг, DWH, наблюдаемость. Логистика CN→RU и финансы." />
   <!-- Иконка -->
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Crect rx='22' ry='22' x='4' y='4' width='92' height='92' fill='%2300d4ff'/%3E%3Ctext x='50' y='62' font-size='50' text-anchor='middle' fill='white' font-family='Arial'%3EDE%3C/text%3E%3C/svg%3E">
+  <link rel="icon" href="img/favicon.svg">
   <!-- Шрифты -->
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <!-- Стили -->
@@ -85,7 +85,7 @@
 
     <div class="grid">
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Стриминг статусов CN→RU">
+        <img src="img/project-streaming.svg" alt="Стриминг статусов CN→RU">
         <div class="project-body">
           <h3>Стриминг CN→RU: статусы и SLA</h3>
           <p>Подключили TMS/WMS, нормализовали статусы, SLA-мониторинг. ↓ слепых зон ≈70%, ↓ штрафов 18%.</p>
@@ -94,7 +94,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Калькулятор логистической стоимости">
+        <img src="img/project-logistics-cost.svg" alt="Калькулятор логистической стоимости">
         <div class="project-body">
           <h3>Полная логистическая стоимость</h3>
           <p>dbt-правила и тесты, единая витрина расходов. Рассчёт — секунды, ошибок меньше ≈40%.</p>
@@ -103,7 +103,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Дивидендная аналитика">
+        <img src="img/project-dividends.svg" alt="Дивидендная аналитика">
         <div class="project-body">
           <h3>Дивидендная аналитика</h3>
           <p>ETL календарей/прайсов, нормализация МСФО/РСБУ, телеграм-сводки. Один источник правды.</p>
@@ -112,7 +112,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Наблюдаемость данных">
+        <img src="img/project-observability.svg" alt="Наблюдаемость данных">
         <div class="project-body">
           <h3>Наблюдаемость и качество</h3>
           <p>SLI/SLA, freshness/uniqueness, алерты. MTTR ↓ ~35%, меньше ложных тревог.</p>
@@ -131,7 +131,7 @@
 
     <div class="testimonials">
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Анонимный директор по операционной логистике">
+        <img class="avatar" src="img/avatar-logistics.svg" alt="Анонимный директор по операционной логистике">
         <blockquote class="quote-text">
           «За 4 недели Артём подключил наши TMS/WMS и навёл порядок в статусах. Слепые зоны по маршрутам заметно сократились,
           а штрафы за просрочки снизились. Дашборды и алерты реально помогают в смене.»
@@ -140,7 +140,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Анонимный руководитель финблока">
+        <img class="avatar" src="img/avatar-finance.svg" alt="Анонимный руководитель финблока">
         <blockquote class="quote-text">
           «Перенёс расчёты полной стоимости в dbt с тестами и версионированием. Теперь считаем быстро и прозрачно,
           ошибки в отчётности сократились примерно на 40%.»
@@ -149,7 +149,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Анонимный продуктовый аналитик">
+        <img class="avatar" src="img/avatar-analytics.svg" alt="Анонимный продуктовый аналитик">
         <blockquote class="quote-text">
           «Витрина дивидендов перестала требовать ручных правок, отчёты уходят автоматически. Наконец-то один источник правды.»
         </blockquote>


### PR DESCRIPTION
## Summary
- move all data URI icons in the landing page into dedicated SVG files with darker stroke styling for light backgrounds
- add tailored SVG illustrations for each project card, testimonial avatar, and favicon, and update the page to reference the new assets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c92b33e9fc8322a30623015e475d4e