### PR TITLE
Switch light hero to SVG asset

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,6 +53,9 @@ p{margin:0 0 16px;max-width:70ch} ul,li{margin:0 0 8px 20px;padding:0}
   width:100%; height:100%; object-fit:cover;
   filter:brightness(.45) blur(2px);
 }
+[data-theme="light"] .hero-bg img{
+  filter:brightness(.9) blur(2px);
+}
 .hero::after{
   content:""; position:absolute; inset:0; z-index:1;
   background:

--- a/img/hero-light.svg
+++ b/img/hero-light.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">Abstract data flow on a bright background</title>
+  <desc id="desc">Soft gradients with subtle charts and connections representing analytics on a light backdrop.</desc>
+  <defs>
+    <radialGradient id="bgGradient" cx="0.15" cy="0.05" r="1.05">
+      <stop offset="0" stop-color="#ffffff" />
+      <stop offset="0.45" stop-color="#eef5ff" />
+      <stop offset="1" stop-color="#f6f7fb" />
+    </radialGradient>
+    <linearGradient id="barGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7c4dff" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#7c4dff" stop-opacity="0.05" />
+    </linearGradient>
+    <linearGradient id="barGradient2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#00d4ff" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#00d4ff" stop-opacity="0.05" />
+    </linearGradient>
+    <linearGradient id="barGradient3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#5b8fff" stop-opacity="0.38" />
+      <stop offset="1" stop-color="#5b8fff" stop-opacity="0.05" />
+    </linearGradient>
+    <linearGradient id="arcGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d4ff" stop-opacity="0.55" />
+      <stop offset="1" stop-color="#7c4dff" stop-opacity="0.35" />
+    </linearGradient>
+    <linearGradient id="pulseGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d4ff" stop-opacity="0.25" />
+      <stop offset="1" stop-color="#00d4ff" stop-opacity="0" />
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bgGradient)" />
+
+  <g opacity="0.55">
+    <ellipse cx="420" cy="160" rx="320" ry="120" fill="#d9e9ff" />
+    <ellipse cx="1280" cy="220" rx="380" ry="160" fill="#dce7ff" />
+    <ellipse cx="820" cy="760" rx="420" ry="160" fill="#e1f8ff" />
+  </g>
+
+  <g opacity="0.45" transform="translate(110,90)">
+    <rect x="0" y="180" width="36" height="220" rx="18" fill="url(#barGradient)" />
+    <rect x="60" y="130" width="36" height="270" rx="18" fill="url(#barGradient3)" />
+    <rect x="120" y="60" width="36" height="340" rx="18" fill="url(#barGradient2)" />
+    <rect x="180" y="210" width="36" height="190" rx="18" fill="url(#barGradient3)" />
+    <rect x="240" y="150" width="36" height="250" rx="18" fill="url(#barGradient2)" />
+    <rect x="300" y="90" width="36" height="310" rx="18" fill="url(#barGradient)" />
+  </g>
+
+  <g opacity="0.35" transform="translate(980,120)">
+    <rect x="120" y="80" width="28" height="260" rx="14" fill="url(#barGradient2)" />
+    <rect x="170" y="150" width="28" height="190" rx="14" fill="url(#barGradient3)" />
+    <rect x="220" y="40" width="28" height="300" rx="14" fill="url(#barGradient)" />
+    <rect x="270" y="100" width="28" height="240" rx="14" fill="url(#barGradient3)" />
+  </g>
+
+  <g stroke-width="2" stroke-linecap="round" stroke="#8fb5ff" opacity="0.5">
+    <path d="M360 470 C520 400 640 420 780 480" fill="none" />
+    <path d="M780 480 C940 540 1100 540 1280 460" fill="none" />
+    <path d="M300 560 C480 520 640 560 820 630" fill="none" />
+  </g>
+
+  <g fill="#00d4ff" opacity="0.4">
+    <circle cx="360" cy="470" r="12" />
+    <circle cx="520" cy="420" r="8" />
+    <circle cx="660" cy="450" r="10" />
+    <circle cx="820" cy="500" r="13" />
+    <circle cx="960" cy="540" r="9" />
+    <circle cx="1100" cy="520" r="11" />
+    <circle cx="1280" cy="460" r="14" />
+    <circle cx="300" cy="560" r="10" />
+    <circle cx="480" cy="520" r="8" />
+    <circle cx="640" cy="560" r="9" />
+    <circle cx="820" cy="630" r="12" />
+  </g>
+
+  <g stroke="url(#arcGradient)" stroke-width="3" fill="none" opacity="0.35">
+    <path d="M260 260 C380 120 540 120 680 260" />
+    <path d="M880 320 C1020 180 1180 200 1300 340" />
+  </g>
+
+  <g opacity="0.25">
+    <circle cx="1120" cy="280" r="80" fill="url(#pulseGradient)" filter="url(#glow)" />
+    <circle cx="520" cy="680" r="90" fill="url(#pulseGradient)" filter="url(#glow)" />
+    <circle cx="1380" cy="640" r="110" fill="url(#pulseGradient)" filter="url(#glow)" />
+  </g>
+
+  <g opacity="0.3">
+    <path d="M1180 700 l60 0 l0 60 l-60 0 z" fill="#7c4dff" fill-opacity="0.15" />
+    <path d="M1260 700 l60 0 l0 60 l-60 0 z" fill="#00d4ff" fill-opacity="0.12" />
+    <path d="M1340 700 l60 0 l0 60 l-60 0 z" fill="#7c4dff" fill-opacity="0.1" />
+    <rect x="520" y="220" width="46" height="46" rx="10" fill="#00d4ff" fill-opacity="0.18" />
+    <rect x="590" y="250" width="36" height="36" rx="8" fill="#7c4dff" fill-opacity="0.18" />
+  </g>
+
+  <g opacity="0.35" stroke="#bcd7ff" stroke-width="1.6" stroke-dasharray="6 10" fill="none">
+    <path d="M260 320 C340 360 420 360 500 320" />
+    <path d="M940 200 C1020 240 1100 240 1180 200" />
+    <path d="M680 620 C760 660 840 660 920 620" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="hero-bg">
-      <img src="img/hero.png" alt="Фоновое изображение: потоки данных" />
+      <img src="img/hero-light.svg" alt="Фоновое изображение: потоки данных" />
     </div>
   </section>
 

--- a/pages/about.html
+++ b/pages/about.html
@@ -8,12 +8,12 @@
   <meta property="og:title" content="Обо мне — Artem Chernov" />
   <meta property="og:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta property="og:url" content="https://jaeviksodertra.github.io/about.html" />
-  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero-light.svg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Обо мне — Artem Chernov" />
   <meta name="twitter:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta name="twitter:url" content="https://jaeviksodertra.github.io/about.html" />
-  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
+  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero-light.svg" />
   <link rel="canonical" href="https://jaeviksodertra.github.io/about.html" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,7 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
-      <img src="../img/hero.png" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
+      <img src="../img/hero-light.svg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 


### PR DESCRIPTION
## Summary
- replace the light hero artwork with a vector SVG to satisfy the no-binary constraint
- point hero, about page preview tags, and profile photo to the new asset

## Testing
- not run (static asset updates only)

------
https://chatgpt.com/codex/tasks/task_e_68c92b3363688322a57ca9942638ed7e