### PR TITLE
Replace placeholder graphics with curated imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="hero-bg">
-      <img src="img/hero-light.svg" alt="Фоновое изображение: потоки данных" />
+      <img src="https://images.unsplash.com/photo-1580894897411-907acb1b6a47?auto=format&fit=crop&w=1600&q=80" alt="Фоновое фото дата-центра с серверами" />
     </div>
   </section>
 
@@ -85,7 +85,7 @@
 
     <div class="grid">
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Стриминг статусов CN→RU">
+        <img src="https://images.unsplash.com/photo-1502209524169-1c91ed1c9e51?auto=format&fit=crop&w=900&q=80" alt="Контейнеровоз в порту в ночное время" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Стриминг CN→RU: статусы и SLA</h3>
           <p>Подключили TMS/WMS, нормализовали статусы, SLA-мониторинг. ↓ слепых зон ≈70%, ↓ штрафов 18%.</p>
@@ -94,7 +94,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Калькулятор логистической стоимости">
+        <img src="https://images.unsplash.com/photo-1515165562835-c4c681bfb81d?auto=format&fit=crop&w=900&q=80" alt="Команда анализирует данные на экранах ноутбуков" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Полная логистическая стоимость</h3>
           <p>dbt-правила и тесты, единая витрина расходов. Рассчёт — секунды, ошибок меньше ≈40%.</p>
@@ -103,7 +103,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Дивидендная аналитика">
+        <img src="https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=900&q=80" alt="Финансовые графики на множестве мониторов" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Дивидендная аналитика</h3>
           <p>ETL календарей/прайсов, нормализация МСФО/РСБУ, телеграм-сводки. Один источник правды.</p>
@@ -112,7 +112,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Наблюдаемость данных">
+        <img src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=900&q=80" alt="Мониторы с графиками и метриками системы" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Наблюдаемость и качество</h3>
           <p>SLI/SLA, freshness/uniqueness, алерты. MTTR ↓ ~35%, меньше ложных тревог.</p>
@@ -131,7 +131,7 @@
 
     <div class="testimonials">
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Анонимный директор по операционной логистике">
+        <img class="avatar" src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=200&q=80" alt="Анонимный директор по операционной логистике" loading="lazy" decoding="async">
         <blockquote class="quote-text">
           «За 4 недели Артём подключил наши TMS/WMS и навёл порядок в статусах. Слепые зоны по маршрутам заметно сократились,
           а штрафы за просрочки снизились. Дашборды и алерты реально помогают в смене.»
@@ -140,7 +140,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Анонимный руководитель финблока">
+        <img class="avatar" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=200&q=80" alt="Анонимный руководитель финблока" loading="lazy" decoding="async">
         <blockquote class="quote-text">
           «Перенёс расчёты полной стоимости в dbt с тестами и версионированием. Теперь считаем быстро и прозрачно,
           ошибки в отчётности сократились примерно на 40%.»
@@ -149,7 +149,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCcgZmlsbD0nbm9uZScgc3Ryb2tlPScjMDBkNGZmJyBzdHJva2Utd2lkdGg9JzInIHN0cm9rZS1saW5lY2FwPSdyb3VuZCcgc3Ryb2tlLWxpbmVqb2luPSdyb3VuZCc+PHBhdGggZD0nTTEwIDEzYTUgNSAwIDAwNi4zLjhsMy0zYTUgNSAwIDAwLTcuMS03LjFsLTEuNSAxLjUnLz48cGF0aCBkPSdNMTQgMTFhNSA1IDAgMDAtNi4zLS44bC0zIDNhNSA1IDAgMDA3LjEgNy4xbDEuNS0xLjUnLz48L3N2Zz4=" alt="Анонимный продуктовый аналитик">
+        <img class="avatar" src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=200&q=80" alt="Анонимный продуктовый аналитик" loading="lazy" decoding="async">
         <blockquote class="quote-text">
           «Витрина дивидендов перестала требовать ручных правок, отчёты уходят автоматически. Наконец-то один источник правды.»
         </blockquote>

--- a/pages/about.html
+++ b/pages/about.html
@@ -8,12 +8,12 @@
   <meta property="og:title" content="Обо мне — Artem Chernov" />
   <meta property="og:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta property="og:url" content="https://jaeviksodertra.github.io/about.html" />
-  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero-light.svg" />
+  <meta property="og:image" content="https://images.unsplash.com/photo-1555949963-aa79dcee981c?auto=format&fit=crop&w=1200&q=80" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Обо мне — Artem Chernov" />
   <meta name="twitter:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta name="twitter:url" content="https://jaeviksodertra.github.io/about.html" />
-  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero-light.svg" />
+  <meta name="twitter:image" content="https://images.unsplash.com/photo-1555949963-aa79dcee981c?auto=format&fit=crop&w=1200&q=80" />
   <link rel="canonical" href="https://jaeviksodertra.github.io/about.html" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,7 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
-      <img src="../img/hero-light.svg" alt="Артём Чернов" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
+      <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=400&q=80" alt="Артём Чернов работает с ноутбуком" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 


### PR DESCRIPTION
## Summary
- swap the hero background and project thumbnails for themed Unsplash photography
- refresh testimonial avatars with realistic portraits from the web
- update the about page preview image metadata and portrait to reference hosted photos

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c94bef276883229c96f9315ddbe855