### PR TITLE
Replace remote image hotlinks with local illustrations

### DIFF
--- a/img/about-portrait.svg
+++ b/img/about-portrait.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-labelledby="title desc">
+  <title id="title">Portrait illustration of Artem Chernov</title>
+  <desc id="desc">Simplified illustrated portrait with gradients aligned to the site's visual style.</desc>
+  <defs>
+    <radialGradient id="portraitBg" cx="0.25" cy="0.2" r="0.9">
+      <stop offset="0" stop-color="#00d4ff" />
+      <stop offset="0.5" stop-color="#132a45" />
+      <stop offset="1" stop-color="#0a1426" />
+    </radialGradient>
+    <linearGradient id="jacket" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1d3755" />
+      <stop offset="1" stop-color="#0f1f33" />
+    </linearGradient>
+    <linearGradient id="shirt" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7c4dff" />
+      <stop offset="1" stop-color="#4b24b7" />
+    </linearGradient>
+  </defs>
+
+  <rect width="400" height="400" rx="200" fill="url(#portraitBg)" />
+  <circle cx="200" cy="150" r="90" fill="#f4f7fb" fill-opacity="0.9" />
+  <path d="M88 340 C118 250 282 250 312 340 Z" fill="url(#jacket)" />
+  <path d="M148 310 C168 260 232 260 252 310 Z" fill="url(#shirt)" />
+  <circle cx="200" cy="160" r="78" fill="#f4f7fb" fill-opacity="0.92" />
+  <path d="M148 150 C158 126 242 126 252 150" fill="none" stroke="#5b7cff" stroke-width="10" stroke-linecap="round" opacity="0.45" />
+  <circle cx="176" cy="174" r="10" fill="#192c46" />
+  <circle cx="224" cy="174" r="10" fill="#192c46" />
+  <path d="M180 210 C190 222 210 222 220 210" fill="none" stroke="#192c46" stroke-width="8" stroke-linecap="round" />
+</svg>

--- a/img/avatar-analytics.svg
+++ b/img/avatar-analytics.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-labelledby="title desc">
+  <title id="title">Avatar illustration: product analyst</title>
+  <desc id="desc">Abstract portrait with turquoise gradients representing a product analyst.</desc>
+  <defs>
+    <radialGradient id="bgAnalyst" cx="0.4" cy="0.25" r="0.85">
+      <stop offset="0" stop-color="#00d4ff" />
+      <stop offset="1" stop-color="#082133" />
+    </radialGradient>
+    <linearGradient id="shirtAnalyst" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#18425b" />
+      <stop offset="1" stop-color="#0c2337" />
+    </linearGradient>
+  </defs>
+
+  <rect width="200" height="200" rx="100" fill="url(#bgAnalyst)" />
+  <circle cx="100" cy="80" r="44" fill="#e8f9ff" fill-opacity="0.92" />
+  <path d="M58 168 C72 130 128 130 142 168 Z" fill="url(#shirtAnalyst)" />
+  <path d="M72 72 C82 54 118 54 128 72" fill="none" stroke="#4cd4ff" stroke-width="6" stroke-linecap="round" opacity="0.45" />
+  <circle cx="86" cy="86" r="6" fill="#12273b" />
+  <circle cx="114" cy="86" r="6" fill="#12273b" />
+  <path d="M88 108 C96 116 104 116 112 108" fill="none" stroke="#12273b" stroke-width="5" stroke-linecap="round" />
+</svg>

--- a/img/avatar-finance.svg
+++ b/img/avatar-finance.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-labelledby="title desc">
+  <title id="title">Avatar illustration: finance lead</title>
+  <desc id="desc">Abstract portrait with teal and violet gradients representing a finance executive.</desc>
+  <defs>
+    <radialGradient id="bgFin" cx="0.6" cy="0.25" r="0.85">
+      <stop offset="0" stop-color="#7c4dff" />
+      <stop offset="1" stop-color="#0b1c33" />
+    </radialGradient>
+    <linearGradient id="shirtFin" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#233a60" />
+      <stop offset="1" stop-color="#15233f" />
+    </linearGradient>
+  </defs>
+
+  <rect width="200" height="200" rx="100" fill="url(#bgFin)" />
+  <circle cx="100" cy="80" r="44" fill="#f2f6ff" fill-opacity="0.9" />
+  <path d="M56 168 C70 130 130 130 144 168 Z" fill="url(#shirtFin)" />
+  <path d="M72 70 C82 52 118 52 128 70" fill="none" stroke="#7c9cff" stroke-width="6" stroke-linecap="round" opacity="0.4" />
+  <circle cx="86" cy="86" r="6" fill="#15233f" />
+  <circle cx="114" cy="86" r="6" fill="#15233f" />
+  <path d="M88 110 C96 118 104 118 112 110" fill="none" stroke="#15233f" stroke-width="5" stroke-linecap="round" />
+</svg>

--- a/img/avatar-logistics.svg
+++ b/img/avatar-logistics.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-labelledby="title desc">
+  <title id="title">Avatar illustration: logistics lead</title>
+  <desc id="desc">Abstract portrait with blue-purple gradients representing a logistics leader.</desc>
+  <defs>
+    <radialGradient id="bg" cx="0.35" cy="0.2" r="0.8">
+      <stop offset="0" stop-color="#00d4ff" />
+      <stop offset="1" stop-color="#1b0f3f" />
+    </radialGradient>
+    <linearGradient id="shirt" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1f3c6d" />
+      <stop offset="1" stop-color="#101d35" />
+    </linearGradient>
+  </defs>
+
+  <rect width="200" height="200" rx="100" fill="url(#bg)" />
+  <circle cx="100" cy="78" r="42" fill="#e9f7ff" fill-opacity="0.85" />
+  <path d="M60 164 C70 130 130 130 140 164 Z" fill="url(#shirt)" />
+  <path d="M70 72 C80 54 120 54 130 72" fill="none" stroke="#4c6cff" stroke-width="6" stroke-linecap="round" opacity="0.45" />
+  <circle cx="84" cy="84" r="6" fill="#0f2843" />
+  <circle cx="116" cy="84" r="6" fill="#0f2843" />
+  <path d="M88 106 C94 112 106 112 112 106" fill="none" stroke="#0f2843" stroke-width="5" stroke-linecap="round" />
+</svg>

--- a/img/project-cost.svg
+++ b/img/project-cost.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Cost analytics illustration</title>
+  <desc id="desc">Stylised stacked cards and charts with gradient background to represent expense transparency.</desc>
+  <defs>
+    <linearGradient id="bgCost" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#120b2b" />
+      <stop offset="1" stop-color="#1b123b" />
+    </linearGradient>
+    <linearGradient id="cardA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4c2bff" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#00d4ff" stop-opacity="0.85" />
+    </linearGradient>
+    <linearGradient id="cardB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1f225c" />
+      <stop offset="1" stop-color="#13173d" />
+    </linearGradient>
+    <linearGradient id="barA" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#00d4ff" />
+      <stop offset="1" stop-color="#0064ff" />
+    </linearGradient>
+    <linearGradient id="barB" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#7c4dff" />
+      <stop offset="1" stop-color="#352175" />
+    </linearGradient>
+  </defs>
+
+  <rect width="900" height="600" fill="url(#bgCost)" />
+
+  <g opacity="0.35">
+    <circle cx="220" cy="160" r="160" fill="#00d4ff" fill-opacity="0.25" />
+    <circle cx="680" cy="120" r="140" fill="#7c4dff" fill-opacity="0.28" />
+    <circle cx="720" cy="460" r="180" fill="#00a6ff" fill-opacity="0.2" />
+  </g>
+
+  <g opacity="0.9">
+    <rect x="190" y="200" width="520" height="300" rx="32" fill="url(#cardB)" stroke="#253068" stroke-width="2" />
+    <rect x="230" y="240" width="260" height="120" rx="18" fill="#141942" stroke="#2b3a7b" stroke-width="1.4" />
+    <rect x="230" y="380" width="260" height="80" rx="18" fill="#141942" stroke="#2b3a7b" stroke-width="1.4" />
+    <rect x="520" y="240" width="150" height="220" rx="18" fill="#141942" stroke="#2b3a7b" stroke-width="1.4" />
+    <rect x="430" y="140" width="240" height="70" rx="20" fill="url(#cardA)" opacity="0.8" />
+  </g>
+
+  <g fill="none" stroke="#00d4ff" stroke-width="3" stroke-linecap="round" opacity="0.6">
+    <path d="M260 290 L320 260 L380 310 L420 270 L460 300" />
+    <path d="M260 430 L320 412 L360 440 L400 420 L440 436" />
+  </g>
+
+  <g fill="none" stroke="#7c4dff" stroke-width="3" stroke-linecap="round" opacity="0.55">
+    <path d="M550 320 L590 280 L630 330 L660 300" />
+  </g>
+
+  <g fill="url(#barA)" opacity="0.9">
+    <rect x="540" y="320" width="28" height="110" rx="8" />
+    <rect x="580" y="300" width="28" height="130" rx="8" />
+    <rect x="620" y="340" width="28" height="90" rx="8" />
+  </g>
+
+  <g fill="url(#barB)" opacity="0.9">
+    <rect x="260" y="260" width="22" height="70" rx="6" />
+    <rect x="300" y="250" width="22" height="80" rx="6" />
+    <rect x="340" y="270" width="22" height="60" rx="6" />
+    <rect x="380" y="255" width="22" height="75" rx="6" />
+  </g>
+
+  <g fill="#00d4ff" opacity="0.7">
+    <circle cx="260" cy="290" r="6" />
+    <circle cx="320" cy="260" r="6" />
+    <circle cx="380" cy="310" r="6" />
+    <circle cx="420" cy="270" r="6" />
+    <circle cx="460" cy="300" r="6" />
+  </g>
+
+  <g fill="#7c4dff" opacity="0.7">
+    <circle cx="260" cy="430" r="5" />
+    <circle cx="320" cy="412" r="5" />
+    <circle cx="360" cy="440" r="5" />
+    <circle cx="400" cy="420" r="5" />
+    <circle cx="440" cy="436" r="5" />
+  </g>
+</svg>

--- a/img/project-dividends.svg
+++ b/img/project-dividends.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Dividend analytics illustration</title>
+  <desc id="desc">Layered dashboards, tickers and graphs reflecting financial analytics for dividends.</desc>
+  <defs>
+    <linearGradient id="bgDiv" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#071725" />
+      <stop offset="1" stop-color="#102e3f" />
+    </linearGradient>
+    <linearGradient id="cardTop" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d4ff" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#7c4dff" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="cardMid" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d2338" />
+      <stop offset="1" stop-color="#081829" />
+    </linearGradient>
+    <linearGradient id="graphLine" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00d4ff" />
+      <stop offset="1" stop-color="#7c4dff" />
+    </linearGradient>
+  </defs>
+
+  <rect width="900" height="600" fill="url(#bgDiv)" />
+
+  <g opacity="0.35">
+    <circle cx="200" cy="160" r="160" fill="#00d4ff" fill-opacity="0.18" />
+    <circle cx="720" cy="180" r="180" fill="#7c4dff" fill-opacity="0.16" />
+    <circle cx="480" cy="460" r="200" fill="#00c2ff" fill-opacity="0.18" />
+  </g>
+
+  <g opacity="0.9">
+    <rect x="200" y="180" width="520" height="280" rx="26" fill="url(#cardMid)" stroke="#143247" stroke-width="2" />
+    <rect x="240" y="220" width="440" height="100" rx="20" fill="#0b2132" stroke="#1d3d53" stroke-width="1.5" />
+    <rect x="240" y="340" width="440" height="80" rx="18" fill="#0b2132" stroke="#1d3d53" stroke-width="1.5" />
+    <rect x="320" y="120" width="320" height="70" rx="20" fill="url(#cardTop)" opacity="0.85" />
+  </g>
+
+  <g fill="none" stroke="url(#graphLine)" stroke-width="4" stroke-linecap="round" opacity="0.8">
+    <path d="M270 360 L330 330 L390 370 L430 340 L470 360 L520 320 L580 350 L620 330 L660 345" />
+  </g>
+
+  <g opacity="0.6" stroke="#00d4ff" stroke-width="3" stroke-linecap="round">
+    <path d="M280 260 L330 235 L380 250 L430 220 L480 245 L530 230 L580 255 L630 240 L680 265" />
+  </g>
+
+  <g opacity="0.5" stroke="#7c4dff" stroke-width="3" stroke-linecap="round">
+    <path d="M280 395 L340 412 L400 388 L460 408 L520 386 L580 400 L640 390" />
+  </g>
+
+  <g fill="#00d4ff" opacity="0.7">
+    <circle cx="280" cy="260" r="6" />
+    <circle cx="330" cy="235" r="6" />
+    <circle cx="380" cy="250" r="6" />
+    <circle cx="430" cy="220" r="6" />
+    <circle cx="480" cy="245" r="6" />
+    <circle cx="530" cy="230" r="6" />
+    <circle cx="580" cy="255" r="6" />
+    <circle cx="630" cy="240" r="6" />
+    <circle cx="680" cy="265" r="6" />
+  </g>
+
+  <g fill="#7c4dff" opacity="0.65">
+    <circle cx="280" cy="395" r="5" />
+    <circle cx="340" cy="412" r="5" />
+    <circle cx="400" cy="388" r="5" />
+    <circle cx="460" cy="408" r="5" />
+    <circle cx="520" cy="386" r="5" />
+    <circle cx="580" cy="400" r="5" />
+    <circle cx="640" cy="390" r="5" />
+  </g>
+
+  <g opacity="0.5" fill="none" stroke="#1f4863" stroke-width="2" stroke-dasharray="12 10">
+    <path d="M200 420 H720" />
+    <path d="M200 300 H720" />
+    <path d="M240 220 V460" />
+    <path d="M680 220 V460" />
+  </g>
+</svg>

--- a/img/project-observability.svg
+++ b/img/project-observability.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Observability illustration</title>
+  <desc id="desc">Multiple screens with charts and status lights reflecting observability and reliability dashboards.</desc>
+  <defs>
+    <linearGradient id="bgObs" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#03101e" />
+      <stop offset="1" stop-color="#0d2233" />
+    </linearGradient>
+    <linearGradient id="screenA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#182c47" />
+      <stop offset="1" stop-color="#0f1f32" />
+    </linearGradient>
+    <linearGradient id="screenB" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#213652" />
+      <stop offset="1" stop-color="#112032" />
+    </linearGradient>
+    <linearGradient id="lineGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d4ff" />
+      <stop offset="1" stop-color="#7c4dff" />
+    </linearGradient>
+  </defs>
+
+  <rect width="900" height="600" fill="url(#bgObs)" />
+
+  <g opacity="0.3">
+    <circle cx="200" cy="160" r="140" fill="#00d4ff" fill-opacity="0.25" />
+    <circle cx="720" cy="140" r="160" fill="#7c4dff" fill-opacity="0.25" />
+    <circle cx="450" cy="470" r="200" fill="#00a6ff" fill-opacity="0.2" />
+  </g>
+
+  <g opacity="0.92">
+    <rect x="180" y="170" width="540" height="260" rx="26" fill="url(#screenA)" stroke="#1f3852" stroke-width="2" />
+    <rect x="220" y="210" width="240" height="160" rx="18" fill="#0f1f33" stroke="#25405b" stroke-width="1.5" />
+    <rect x="480" y="210" width="180" height="120" rx="18" fill="#0f1f33" stroke="#25405b" stroke-width="1.5" />
+    <rect x="480" y="340" width="180" height="70" rx="16" fill="#0f1f33" stroke="#25405b" stroke-width="1.5" />
+    <rect x="260" y="120" width="320" height="60" rx="20" fill="url(#screenB)" opacity="0.85" />
+    <rect x="240" y="460" width="420" height="80" rx="20" fill="url(#screenB)" opacity="0.85" />
+  </g>
+
+  <g fill="none" stroke="url(#lineGradient)" stroke-width="3" stroke-linecap="round" opacity="0.75">
+    <path d="M240 250 L280 220 L320 245 L360 210 L400 240 L440 230 L460 250" />
+    <path d="M520 260 L560 230 L600 260 L640 240" />
+    <path d="M260 500 L320 480 L380 510 L440 492 L500 515 L560 500 L620 520" />
+  </g>
+
+  <g opacity="0.6" stroke="#00d4ff" stroke-width="2.6" stroke-linecap="round">
+    <path d="M240 320 L280 300 L320 330 L360 310 L400 336 L440 320" />
+  </g>
+
+  <g opacity="0.55" stroke="#7c4dff" stroke-width="2.4" stroke-linecap="round">
+    <path d="M520 300 L560 320 L600 290 L640 310" />
+  </g>
+
+  <g fill="#00d4ff" opacity="0.75">
+    <circle cx="240" cy="250" r="6" />
+    <circle cx="280" cy="220" r="6" />
+    <circle cx="320" cy="245" r="6" />
+    <circle cx="360" cy="210" r="6" />
+    <circle cx="400" cy="240" r="6" />
+    <circle cx="440" cy="230" r="6" />
+    <circle cx="460" cy="250" r="6" />
+    <circle cx="520" cy="260" r="6" />
+    <circle cx="560" cy="230" r="6" />
+    <circle cx="600" cy="260" r="6" />
+    <circle cx="640" cy="240" r="6" />
+  </g>
+
+  <g fill="#13d89f" opacity="0.8">
+    <circle cx="520" cy="360" r="7" />
+    <circle cx="560" cy="360" r="7" />
+    <circle cx="600" cy="360" r="7" />
+    <circle cx="640" cy="360" r="7" />
+  </g>
+
+  <g fill="#ffb400" opacity="0.85">
+    <circle cx="520" cy="384" r="6" />
+    <circle cx="560" cy="384" r="6" />
+    <circle cx="600" cy="384" r="6" />
+    <circle cx="640" cy="384" r="6" />
+  </g>
+
+  <g fill="#ff6b6b" opacity="0.85">
+    <circle cx="520" cy="408" r="6" />
+    <circle cx="560" cy="408" r="6" />
+    <circle cx="600" cy="408" r="6" />
+    <circle cx="640" cy="408" r="6" />
+  </g>
+</svg>

--- a/img/project-streaming.svg
+++ b/img/project-streaming.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Logistics streaming dashboard illustration</title>
+  <desc id="desc">Gradient background with stylised shipping containers and timeline connections to symbolise logistics monitoring.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#061837" />
+      <stop offset="1" stop-color="#0c2b4f" />
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00d4ff" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#7c4dff" stop-opacity="0.15" />
+    </linearGradient>
+  </defs>
+
+  <rect width="900" height="600" fill="url(#bg)" />
+
+  <g opacity="0.55">
+    <circle cx="140" cy="120" r="120" fill="#00d4ff" fill-opacity="0.12" />
+    <circle cx="740" cy="80" r="140" fill="#7c4dff" fill-opacity="0.18" />
+    <circle cx="620" cy="520" r="170" fill="#00a4ff" fill-opacity="0.14" />
+    <circle cx="240" cy="500" r="140" fill="#7c4dff" fill-opacity="0.13" />
+  </g>
+
+  <g fill="#0b1f3f" stroke="#16365f" stroke-width="2" opacity="0.85">
+    <rect x="80" y="330" width="180" height="120" rx="14" />
+    <rect x="280" y="300" width="200" height="140" rx="16" />
+    <rect x="510" y="320" width="210" height="130" rx="16" />
+  </g>
+
+  <g stroke="#122b4d" stroke-width="2" opacity="0.6">
+    <line x1="80" y1="370" x2="260" y2="260" />
+    <line x1="260" y1="260" x2="410" y2="230" />
+    <line x1="410" y1="230" x2="580" y2="250" />
+    <line x1="580" y1="250" x2="720" y2="210" />
+  </g>
+
+  <g fill="none" stroke="#00d4ff" stroke-width="3" stroke-linecap="round" opacity="0.55">
+    <polyline points="120 380 220 280 360 260 520 280 660 240 760 280" />
+  </g>
+
+  <g opacity="0.35" stroke="#7c4dff" stroke-width="4" stroke-linecap="round">
+    <path d="M100 450 C 220 430 280 480 360 470" />
+    <path d="M380 470 C 460 460 540 500 620 490" />
+    <path d="M640 490 C 720 480 780 500 820 520" />
+  </g>
+
+  <g stroke="#132e52" stroke-width="4" stroke-linecap="round" opacity="0.75">
+    <line x1="120" y1="360" x2="220" y2="360" />
+    <line x1="300" y1="340" x2="460" y2="340" />
+    <line x1="300" y1="376" x2="460" y2="376" />
+    <line x1="300" y1="412" x2="460" y2="412" />
+    <line x1="540" y1="356" x2="700" y2="356" />
+    <line x1="540" y1="392" x2="700" y2="392" />
+    <line x1="540" y1="428" x2="700" y2="428" />
+  </g>
+
+  <g opacity="0.9">
+    <rect x="84" y="334" width="172" height="48" rx="10" fill="#0c274d" stroke="#00d4ff" stroke-width="1.6" />
+    <rect x="288" y="304" width="188" height="52" rx="12" fill="#102f58" stroke="#7c4dff" stroke-width="1.6" />
+    <rect x="520" y="324" width="190" height="50" rx="12" fill="#102f58" stroke="#00d4ff" stroke-width="1.6" />
+  </g>
+
+  <g opacity="0.4" fill="none" stroke="url(#glow)" stroke-width="3" stroke-dasharray="12 12">
+    <path d="M160 160 C 300 220 420 180 520 240" />
+    <path d="M520 240 C 640 300 720 260 820 320" />
+  </g>
+
+  <g fill="#00d4ff" opacity="0.7">
+    <circle cx="120" cy="380" r="6" />
+    <circle cx="220" cy="280" r="8" />
+    <circle cx="360" cy="260" r="9" />
+    <circle cx="520" cy="280" r="8" />
+    <circle cx="660" cy="240" r="10" />
+    <circle cx="760" cy="280" r="7" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="hero-bg">
-      <img src="https://images.unsplash.com/photo-1580894897411-907acb1b6a47?auto=format&fit=crop&w=1600&q=80" alt="Фоновое фото дата-центра с серверами" />
+      <img src="img/hero-light.svg" alt="Абстрактная иллюстрация потоков данных" />
     </div>
   </section>
 
@@ -85,7 +85,7 @@
 
     <div class="grid">
       <article class="project reveal">
-        <img src="https://images.unsplash.com/photo-1502209524169-1c91ed1c9e51?auto=format&fit=crop&w=900&q=80" alt="Контейнеровоз в порту в ночное время" loading="lazy" decoding="async">
+        <img src="img/project-streaming.svg" alt="Иллюстрация стриминга логистических статусов" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Стриминг CN→RU: статусы и SLA</h3>
           <p>Подключили TMS/WMS, нормализовали статусы, SLA-мониторинг. ↓ слепых зон ≈70%, ↓ штрафов 18%.</p>
@@ -94,7 +94,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="https://images.unsplash.com/photo-1515165562835-c4c681bfb81d?auto=format&fit=crop&w=900&q=80" alt="Команда анализирует данные на экранах ноутбуков" loading="lazy" decoding="async">
+        <img src="img/project-cost.svg" alt="Иллюстрация расчёта полной логистической стоимости" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Полная логистическая стоимость</h3>
           <p>dbt-правила и тесты, единая витрина расходов. Рассчёт — секунды, ошибок меньше ≈40%.</p>
@@ -103,7 +103,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="https://images.unsplash.com/photo-1450101499163-c8848c66ca85?auto=format&fit=crop&w=900&q=80" alt="Финансовые графики на множестве мониторов" loading="lazy" decoding="async">
+        <img src="img/project-dividends.svg" alt="Иллюстрация витрины дивидендов" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Дивидендная аналитика</h3>
           <p>ETL календарей/прайсов, нормализация МСФО/РСБУ, телеграм-сводки. Один источник правды.</p>
@@ -112,7 +112,7 @@
       </article>
 
       <article class="project reveal">
-        <img src="https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=900&q=80" alt="Мониторы с графиками и метриками системы" loading="lazy" decoding="async">
+        <img src="img/project-observability.svg" alt="Иллюстрация наблюдаемости и метрик" loading="lazy" decoding="async">
         <div class="project-body">
           <h3>Наблюдаемость и качество</h3>
           <p>SLI/SLA, freshness/uniqueness, алерты. MTTR ↓ ~35%, меньше ложных тревог.</p>
@@ -131,7 +131,7 @@
 
     <div class="testimonials">
       <figure class="quote reveal">
-        <img class="avatar" src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=200&q=80" alt="Анонимный директор по операционной логистике" loading="lazy" decoding="async">
+        <img class="avatar" src="img/avatar-logistics.svg" alt="Иллюстрация директора по операционной логистике" loading="lazy" decoding="async">
         <blockquote class="quote-text">
           «За 4 недели Артём подключил наши TMS/WMS и навёл порядок в статусах. Слепые зоны по маршрутам заметно сократились,
           а штрафы за просрочки снизились. Дашборды и алерты реально помогают в смене.»
@@ -140,7 +140,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=200&q=80" alt="Анонимный руководитель финблока" loading="lazy" decoding="async">
+        <img class="avatar" src="img/avatar-finance.svg" alt="Иллюстрация руководителя финблока" loading="lazy" decoding="async">
         <blockquote class="quote-text">
           «Перенёс расчёты полной стоимости в dbt с тестами и версионированием. Теперь считаем быстро и прозрачно,
           ошибки в отчётности сократились примерно на 40%.»
@@ -149,7 +149,7 @@
       </figure>
 
       <figure class="quote reveal">
-        <img class="avatar" src="https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=200&q=80" alt="Анонимный продуктовый аналитик" loading="lazy" decoding="async">
+        <img class="avatar" src="img/avatar-analytics.svg" alt="Иллюстрация продуктового аналитика" loading="lazy" decoding="async">
         <blockquote class="quote-text">
           «Витрина дивидендов перестала требовать ручных правок, отчёты уходят автоматически. Наконец-то один источник правды.»
         </blockquote>

--- a/pages/about.html
+++ b/pages/about.html
@@ -8,12 +8,12 @@
   <meta property="og:title" content="Обо мне — Artem Chernov" />
   <meta property="og:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta property="og:url" content="https://jaeviksodertra.github.io/about.html" />
-  <meta property="og:image" content="https://images.unsplash.com/photo-1555949963-aa79dcee981c?auto=format&fit=crop&w=1200&q=80" />
+  <meta property="og:image" content="https://jaeviksodertra.github.io/img/hero.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Обо мне — Artem Chernov" />
   <meta name="twitter:description" content="Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию»." />
   <meta name="twitter:url" content="https://jaeviksodertra.github.io/about.html" />
-  <meta name="twitter:image" content="https://images.unsplash.com/photo-1555949963-aa79dcee981c?auto=format&fit=crop&w=1200&q=80" />
+  <meta name="twitter:image" content="https://jaeviksodertra.github.io/img/hero.png" />
   <link rel="canonical" href="https://jaeviksodertra.github.io/about.html" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -36,7 +36,7 @@
   <main class="container section">
     <div class="section-header">
       <h2>Обо мне</h2>
-      <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=400&q=80" alt="Артём Чернов работает с ноутбуком" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
+      <img src="../img/about-portrait.svg" alt="Иллюстрация Артёма Чернова за работой" class="about-photo" loading="lazy" decoding="async" width="200" height="200" />
       <p>Мидл дата-инженер. Делаю устойчивые пайплайны, прозрачные модели и наблюдаемость «по умолчанию».</p>
     </div>
 


### PR DESCRIPTION
## Summary
- replace the hero, project, and testimonial imagery with locally hosted SVG illustrations so they always load on the site
- update the about page portrait and social preview image references to the new local assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c94fb333c08322b396870a77b56f4c